### PR TITLE
44 - Improving logging

### DIFF
--- a/src/Baballonia.Android/Captures/AndroidCamera2Capture.cs
+++ b/src/Baballonia.Android/Captures/AndroidCamera2Capture.cs
@@ -9,6 +9,7 @@ using Android.Util;
 using Android.Views;
 using Baballonia.Services.Inference;
 using Java.Lang;
+using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -24,7 +25,7 @@ namespace Baballonia.Android.Captures;
 /// </summary>
 public class AndroidCamera2Capture : Capture
 {
-    public override HashSet<Regex> Connections { get; set; }
+    public override HashSet<Regex> Connections { get; set; } = new();
 
     private readonly Context _context;
     private UsbDevice _usbDevice;
@@ -39,7 +40,7 @@ public class AndroidCamera2Capture : Capture
     private readonly object _frameLock = new();
     private bool _isCapturing;
 
-    public AndroidCamera2Capture(string url) : base(url)
+    public AndroidCamera2Capture(string url, object? logger = null) : base(url)
     {
         _context = Application.Context;
         _cameraManager = (CameraManager)_context.GetSystemService(Context.CameraService)!;

--- a/src/Baballonia.Android/Captures/IPCameraCapture.cs
+++ b/src/Baballonia.Android/Captures/IPCameraCapture.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Baballonia.Services.Inference;
+using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using Capture = Baballonia.SDK.Capture;
 
@@ -19,9 +20,9 @@ namespace Baballonia.Android.Captures;
 /// https://github.com/Larry57/SimpleMJPEGStreamViewer
 /// https://stackoverflow.com/questions/3801275/how-to-convert-image-to-byte-array
 /// </summary>
-public sealed class IpCameraCapture(string url) : Capture(url)
+public sealed class IpCameraCapture(string url, object? logger = null) : Capture(url)
 {
-    public override HashSet<Regex> Connections { get; set; }
+    public override HashSet<Regex> Connections { get; set; } = new();
 
 
     private readonly CancellationTokenSource _cancellationTokenSource = new();

--- a/src/Baballonia.Desktop/DesktopDeviceEnumerator.cs
+++ b/src/Baballonia.Desktop/DesktopDeviceEnumerator.cs
@@ -17,21 +17,11 @@ using DirectShowLib;
 
 namespace Baballonia.Desktop;
 
-public sealed class DesktopDeviceEnumerator : IDeviceEnumerator
+public sealed class DesktopDeviceEnumerator(ILogger<DesktopDeviceEnumerator>? logger = null) : IDeviceEnumerator
 {
-    private readonly ILogger<DesktopDeviceEnumerator>? _logger;
+    private readonly ILogger<DesktopDeviceEnumerator>? _logger = logger;
     
     public Dictionary<string, string> Cameras { get; set; } = null!;
-
-    public DesktopDeviceEnumerator()
-    {
-        _logger = null;
-    }
-
-    public DesktopDeviceEnumerator(ILogger<DesktopDeviceEnumerator> logger)
-    {
-        _logger = logger;
-    }
 
     /// <summary>
     /// Lists available cameras with friendly names as dictionary keys and device identifiers as values.

--- a/src/Baballonia.Desktop/Program.cs
+++ b/src/Baballonia.Desktop/Program.cs
@@ -8,6 +8,7 @@ using Baballonia.Views;
 using System;
 using Baballonia.Helpers;
 using Velopack;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Baballonia.Desktop;
 

--- a/src/Baballonia.OpenCVCapture/Baballonia.OpenCVCapture.csproj
+++ b/src/Baballonia.OpenCVCapture/Baballonia.OpenCVCapture.csproj
@@ -10,4 +10,8 @@
       <ProjectReference Include="..\Baballonia.SDK\Baballonia.SDK.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/Baballonia.OpenCVCapture/OpenCvCapture.cs
+++ b/src/Baballonia.OpenCVCapture/OpenCvCapture.cs
@@ -8,7 +8,7 @@ namespace Baballonia.OpenCVCapture;
 /// <summary>
 /// Wrapper class for OpenCV
 /// </summary>
-public sealed partial class OpenCvCapture : Capture
+public sealed partial class OpenCvCapture(string url, object? logger = null) : Capture(url)
 {
     // Numbers only, http or GStreamer pipeline
     [GeneratedRegex(@"^\d+$|^https?://.*|^/dev/video\d+$|\s+!\s*appsink$|\.local$", RegexOptions.Compiled | RegexOptions.CultureInvariant)]
@@ -16,22 +16,12 @@ public sealed partial class OpenCvCapture : Capture
 
     public override HashSet<Regex> Connections { get; set; } = [MyRegex()];
 
-    private readonly ILogger? _logger;
+    private readonly ILogger? _logger = logger as ILogger;
     private VideoCapture? _videoCapture;
     private static readonly VideoCaptureAPIs PreferredBackend;
 
     private Task? _updateTask;
     private readonly CancellationTokenSource _updateTaskCts = new();
-
-    public OpenCvCapture(string url) : base(url)
-    {
-        _logger = null;
-    }
-
-    public OpenCvCapture(string url, object logger) : base(url)
-    {
-        _logger = logger as ILogger;
-    }
 
     static OpenCvCapture()
     {

--- a/src/Baballonia.OpenCVCapture/OpenCvCapture.cs
+++ b/src/Baballonia.OpenCVCapture/OpenCvCapture.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using Capture = Baballonia.SDK.Capture;
 
@@ -7,7 +8,7 @@ namespace Baballonia.OpenCVCapture;
 /// <summary>
 /// Wrapper class for OpenCV
 /// </summary>
-public sealed partial class OpenCvCapture(string url) : Capture(url)
+public sealed partial class OpenCvCapture : Capture
 {
     // Numbers only, http or GStreamer pipeline
     [GeneratedRegex(@"^\d+$|^https?://.*|^/dev/video\d+$|\s+!\s*appsink$|\.local$", RegexOptions.Compiled | RegexOptions.CultureInvariant)]
@@ -15,11 +16,22 @@ public sealed partial class OpenCvCapture(string url) : Capture(url)
 
     public override HashSet<Regex> Connections { get; set; } = [MyRegex()];
 
+    private readonly ILogger? _logger;
     private VideoCapture? _videoCapture;
     private static readonly VideoCaptureAPIs PreferredBackend;
 
     private Task? _updateTask;
     private readonly CancellationTokenSource _updateTaskCts = new();
+
+    public OpenCvCapture(string url) : base(url)
+    {
+        _logger = null;
+    }
+
+    public OpenCvCapture(string url, object logger) : base(url)
+    {
+        _logger = logger as ILogger;
+    }
 
     static OpenCvCapture()
     {
@@ -46,17 +58,40 @@ public sealed partial class OpenCvCapture(string url) : Capture(url)
 
     public override async Task<bool> StartCapture()
     {
+        LogDebug("=== STARTING CAMERA CAPTURE ===");
+        LogDebug("Operating System: " + Environment.OSVersion);
+        LogDebug("Camera Source URL: '" + Url + "'");
+        LogDebug("Preferred Backend: " + PreferredBackend);
+        LogDebug("OpenCV Version: " + Cv2.GetVersionString());
+        
         using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
         {
             try
             {
                 if (int.TryParse(Url, out var index))
+                {
+                    LogDebug("URL is numeric camera index: " + index);
+                    LogDebug("Creating VideoCapture from camera index " + index + " with backend " + PreferredBackend);
                     _videoCapture = await Task.Run(() => VideoCapture.FromCamera(index, PreferredBackend), cts.Token);
+                }
                 else
+                {
+                    LogDebug("URL is string-based: '" + Url + "'");
+                    LogDebug("Creating VideoCapture from URL string (backend will be auto-detected)");
                     _videoCapture = await Task.Run(() => new VideoCapture(Url), cts.Token);
+                }
+                
+                LogDebug("VideoCapture instance created successfully");
             }
-            catch (Exception)
+            catch (OperationCanceledException)
             {
+                LogWarning("Camera capture initialization timed out after 5 seconds for URL: '" + Url + "'");
+                IsReady = false;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                LogError(ex, "Error creating VideoCapture for URL: '" + Url + "'");
                 IsReady = false;
                 return false;
             }
@@ -64,50 +99,167 @@ public sealed partial class OpenCvCapture(string url) : Capture(url)
 
         // Handle edge case cameras like the Varjo Aero that send frames in YUV
         // This won't activate the IR illuminators, but it's a good idea to standardize inputs
+        LogDebug("Setting ConvertRgb to true for standardized input");
         _videoCapture.ConvertRgb = true;
         IsReady = _videoCapture.IsOpened();
-
-        CancellationToken token = _updateTaskCts.Token;
-        _updateTask = Task.Run(() => VideoCapture_UpdateLoop(_videoCapture, token));
+        
+        LogDebug("VideoCapture.IsOpened(): " + IsReady);
+        
+        if (!IsReady)
+        {
+            LogWarning("Camera failed to open - checking potential issues...");
+            LogWarning("Camera URL: '" + Url + "'");
+            LogWarning("Backend: " + PreferredBackend);
+            LogWarning("This could be due to: camera already in use, permissions, driver issues, or invalid URL");
+        }
+        
+        if (IsReady)
+        {
+            var width = _videoCapture.Get(VideoCaptureProperties.FrameWidth);
+            var height = _videoCapture.Get(VideoCaptureProperties.FrameHeight);
+            var fps = _videoCapture.Get(VideoCaptureProperties.Fps);
+            var fourcc = _videoCapture.Get(VideoCaptureProperties.FourCC);
+            var bufferSize = _videoCapture.Get(VideoCaptureProperties.BufferSize);
+            var brightness = _videoCapture.Get(VideoCaptureProperties.Brightness);
+            var contrast = _videoCapture.Get(VideoCaptureProperties.Contrast);
+            var saturation = _videoCapture.Get(VideoCaptureProperties.Saturation);
+            var gain = _videoCapture.Get(VideoCaptureProperties.Gain);
+            var exposure = _videoCapture.Get(VideoCaptureProperties.Exposure);
+            var autoExposure = _videoCapture.Get(VideoCaptureProperties.AutoExposure);
+            
+            LogDebug("=== CAMERA INITIALIZATION COMPLETE ===");
+            LogDebug("Camera Source: " + Url);
+            LogDebug("Backend: " + PreferredBackend);
+            LogDebug("Resolution: " + width + "x" + height);
+            LogDebug("Frame Rate: " + fps + " FPS");
+            LogDebug("FourCC Code: " + fourcc + " (hex: " + ((int)fourcc).ToString("X8") + ")");
+            LogDebug("Buffer Size: " + bufferSize);
+            LogDebug("Brightness: " + brightness);
+            LogDebug("Contrast: " + contrast);
+            LogDebug("Saturation: " + saturation);
+            LogDebug("Gain: " + gain);
+            LogDebug("Exposure: " + exposure);
+            LogDebug("Auto Exposure: " + autoExposure);
+            LogDebug("Convert RGB: " + _videoCapture.ConvertRgb);
+            LogDebug("============================================");
+            
+            CancellationToken token = _updateTaskCts.Token;
+            LogDebug("Starting video capture update loop");
+            _updateTask = Task.Run(() => VideoCapture_UpdateLoop(_videoCapture, token));
+        }
 
         return IsReady;
     }
 
+    private void LogDebug(string message)
+    {
+        _logger?.LogInformation(message);
+    }
+
+    private void LogWarning(string message)
+    {
+        _logger?.LogWarning(message);
+    }
+
+    private void LogError(Exception ex, string message)
+    {
+        _logger?.LogError(ex, message);
+    }
+
     private Task VideoCapture_UpdateLoop(VideoCapture capture, CancellationToken ct)
     {
+        bool wasReady = IsReady;
+        int consecutiveFailures = 0;
+        const int maxFailuresBeforeWarning = 5; // Log warning after 5 consecutive failures
+        
         while (!ct.IsCancellationRequested)
         {
             try
             {
-                IsReady = capture.Read(RawMat);
+                bool currentFrameSuccess = capture.Read(RawMat);
+                
+                if (currentFrameSuccess)
+                {
+                    if (!wasReady && consecutiveFailures > 0)
+                    {
+                        LogWarning($"Camera connection restored for URL '{Url}' after {consecutiveFailures} failed attempts");
+                        consecutiveFailures = 0;
+                    }
+                    IsReady = true;
+                    wasReady = true;
+                }
+                else
+                {
+                    consecutiveFailures++;
+                    
+                    if (wasReady)
+                    {
+                        LogWarning($"CAMERA DISCONNECTION DETECTED: Frame read failed for camera URL '{Url}' (Backend: {PreferredBackend})");
+                        LogWarning("This typically indicates: USB disconnection, camera in use by another application, or hardware failure");
+                        wasReady = false;
+                    }
+                    else if (consecutiveFailures == maxFailuresBeforeWarning)
+                    {
+                        LogWarning($"Camera remains disconnected after {consecutiveFailures} attempts for URL '{Url}'");
+                    }
+                    else if (consecutiveFailures % 50 == 0) // Log every 50 failures (about every 1 second)
+                    {
+                        LogWarning($"Camera still disconnected after {consecutiveFailures} attempts for URL '{Url}'");
+                    }
+                    
+                    IsReady = false;
+                }
+                
                 Task.Delay(20, ct).Wait(ct);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // ignored
+                consecutiveFailures++;
+                if (wasReady)
+                {
+                    LogError(ex, $"CAMERA EXCEPTION DETECTED: Exception occurred in capture loop for URL '{Url}'");
+                    wasReady = false;
+                }
+                else if (consecutiveFailures % 50 == 0)
+                {
+                    LogError(ex, $"Ongoing camera exception for URL '{Url}' after {consecutiveFailures} attempts");
+                }
+                IsReady = false;
             }
         }
 
+        LogDebug($"Video capture update loop terminated for URL '{Url}'");
         return Task.CompletedTask;
     }
 
     public override Task<bool> StopCapture()
     {
+        LogDebug($"StopCapture requested for camera URL '{Url}'");
+        
         if (_videoCapture is null)
+        {
+            LogDebug("StopCapture: VideoCapture is already null, returning false");
             return Task.FromResult(false);
+        }
 
+        LogDebug("Cancelling video capture update task...");
         if (_updateTask != null) {
             _updateTaskCts.Cancel();
             _updateTask.Wait();
+            LogDebug("Video capture update task cancelled successfully");
         }
 
         IsReady = false;
         if (_videoCapture != null)
         {
+            LogDebug("Releasing and disposing VideoCapture instance...");
             _videoCapture.Release();
             _videoCapture.Dispose();
             _videoCapture = null;
+            LogDebug("VideoCapture released and disposed successfully");
         }
+        
+        LogDebug($"Camera capture stopped successfully for URL '{Url}'");
         return Task.FromResult(true);
     }
 }

--- a/src/Baballonia.OpenCVCapture/OpenCvCapture.cs
+++ b/src/Baballonia.OpenCVCapture/OpenCvCapture.cs
@@ -115,33 +115,7 @@ public sealed partial class OpenCvCapture : Capture
         
         if (IsReady)
         {
-            var width = _videoCapture.Get(VideoCaptureProperties.FrameWidth);
-            var height = _videoCapture.Get(VideoCaptureProperties.FrameHeight);
-            var fps = _videoCapture.Get(VideoCaptureProperties.Fps);
-            var fourcc = _videoCapture.Get(VideoCaptureProperties.FourCC);
-            var bufferSize = _videoCapture.Get(VideoCaptureProperties.BufferSize);
-            var brightness = _videoCapture.Get(VideoCaptureProperties.Brightness);
-            var contrast = _videoCapture.Get(VideoCaptureProperties.Contrast);
-            var saturation = _videoCapture.Get(VideoCaptureProperties.Saturation);
-            var gain = _videoCapture.Get(VideoCaptureProperties.Gain);
-            var exposure = _videoCapture.Get(VideoCaptureProperties.Exposure);
-            var autoExposure = _videoCapture.Get(VideoCaptureProperties.AutoExposure);
-            
-            LogDebug("=== CAMERA INITIALIZATION COMPLETE ===");
-            LogDebug("Camera Source: " + Url);
-            LogDebug("Backend: " + PreferredBackend);
-            LogDebug("Resolution: " + width + "x" + height);
-            LogDebug("Frame Rate: " + fps + " FPS");
-            LogDebug("FourCC Code: " + fourcc + " (hex: " + ((int)fourcc).ToString("X8") + ")");
-            LogDebug("Buffer Size: " + bufferSize);
-            LogDebug("Brightness: " + brightness);
-            LogDebug("Contrast: " + contrast);
-            LogDebug("Saturation: " + saturation);
-            LogDebug("Gain: " + gain);
-            LogDebug("Exposure: " + exposure);
-            LogDebug("Auto Exposure: " + autoExposure);
-            LogDebug("Convert RGB: " + _videoCapture.ConvertRgb);
-            LogDebug("============================================");
+            LogCameraProperties();
             
             CancellationToken token = _updateTaskCts.Token;
             LogDebug("Starting video capture update loop");
@@ -164,6 +138,61 @@ public sealed partial class OpenCvCapture : Capture
     private void LogError(Exception ex, string message)
     {
         _logger?.LogError(ex, message);
+    }
+
+    /// <summary>
+    /// Safely logs all camera properties with comprehensive error handling
+    /// </summary>
+    private void LogCameraProperties()
+    {
+        if (_videoCapture == null || !_videoCapture.IsOpened())
+        {
+            LogWarning("Cannot log camera properties: VideoCapture is null or not opened");
+            return;
+        }
+
+        try
+        {
+            LogDebug("=== CAMERA INITIALIZATION COMPLETE ===");
+            LogDebug("Camera Source: " + Url);
+            LogDebug("Backend: " + PreferredBackend);
+
+            // Get all properties safely
+            var width = _videoCapture.Get(VideoCaptureProperties.FrameWidth);
+            var height = _videoCapture.Get(VideoCaptureProperties.FrameHeight);
+            var fps = _videoCapture.Get(VideoCaptureProperties.Fps);
+            var fourcc = _videoCapture.Get(VideoCaptureProperties.FourCC);
+            var bufferSize = _videoCapture.Get(VideoCaptureProperties.BufferSize);
+            var brightness = _videoCapture.Get(VideoCaptureProperties.Brightness);
+            var contrast = _videoCapture.Get(VideoCaptureProperties.Contrast);
+            var saturation = _videoCapture.Get(VideoCaptureProperties.Saturation);
+            var gain = _videoCapture.Get(VideoCaptureProperties.Gain);
+            var exposure = _videoCapture.Get(VideoCaptureProperties.Exposure);
+            var autoExposure = _videoCapture.Get(VideoCaptureProperties.AutoExposure);
+
+            // Log all properties
+            LogDebug("Resolution: " + (width >= 0 ? width.ToString() : "Unknown") + "x" + (height >= 0 ? height.ToString() : "Unknown"));
+            LogDebug("Frame Rate: " + (fps >= 0 ? fps + " FPS" : "Unknown"));
+            LogDebug("FourCC Code: " + (fourcc >= 0 ? fourcc + " (hex: " + ((int)fourcc).ToString("X8") + ")" : "Unknown"));
+            LogDebug("Buffer Size: " + (bufferSize >= 0 ? bufferSize.ToString() : "Unknown"));
+            LogDebug("Brightness: " + (brightness >= 0 ? brightness.ToString() : "Unknown"));
+            LogDebug("Contrast: " + (contrast >= 0 ? contrast.ToString() : "Unknown"));
+            LogDebug("Saturation: " + (saturation >= 0 ? saturation.ToString() : "Unknown"));
+            LogDebug("Gain: " + (gain >= 0 ? gain.ToString() : "Unknown"));
+            LogDebug("Exposure: " + (exposure >= 0 ? exposure.ToString() : "Unknown"));
+            LogDebug("Auto Exposure: " + (autoExposure >= 0 ? autoExposure.ToString() : "Unknown"));
+            LogDebug("Convert RGB: " + _videoCapture.ConvertRgb);
+            LogDebug("============================================");
+        }
+        catch (Exception ex)
+        {
+            LogError(ex, "Failed to retrieve camera properties for logging. This may indicate camera hardware or driver issues.");
+            LogDebug("=== CAMERA INITIALIZATION COMPLETE (Limited Info) ===");
+            LogDebug("Camera Source: " + Url);
+            LogDebug("Backend: " + PreferredBackend);
+            LogDebug("Note: Camera properties could not be retrieved due to an error");
+            LogDebug("============================================");
+        }
     }
 
     private Task VideoCapture_UpdateLoop(VideoCapture capture, CancellationToken ct)

--- a/src/Baballonia.SerialCameraCapture/Baballonia.SerialCameraCapture.csproj
+++ b/src/Baballonia.SerialCameraCapture/Baballonia.SerialCameraCapture.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.IO.Ports" Version="9.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Baballonia.SerialCameraCapture/SerialCameraCapture.cs
+++ b/src/Baballonia.SerialCameraCapture/SerialCameraCapture.cs
@@ -2,6 +2,7 @@
 using System.IO.Ports;
 using System.Numerics;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using Capture = Baballonia.SDK.Capture;
 
@@ -11,7 +12,7 @@ namespace Baballonia.SerialCameraCapture;
 /// Serial Camera capture class intended for use on Desktop platforms
 /// Babble-board specific implementation, assumes a fixed camera size of 240x240
 /// </summary>
-public sealed class SerialCameraCapture(string portName) : Capture(portName), IDisposable
+public sealed class SerialCameraCapture(string portName, object? logger = null) : Capture(portName), IDisposable
 {
     public override HashSet<Regex> Connections { get; set; } =
     [
@@ -25,6 +26,7 @@ public sealed class SerialCameraCapture(string portName) : Capture(portName), ID
     private const ulong EtvrHeader = 0xd8ff0000a1ffa0ff, EtvrHeaderMask = 0xffff0000ffffffff;
     private bool _isDisposed;
 
+    private readonly ILogger? _logger = logger as ILogger;
     private readonly SerialPort _serialPort = new()
     {
         PortName = portName,
@@ -35,72 +37,126 @@ public sealed class SerialCameraCapture(string portName) : Capture(portName), ID
 
     public override Task<bool> StartCapture()
     {
+        LogDebug("=== STARTING SERIAL CAMERA CAPTURE ===");
+        LogDebug("Port Name: '" + portName + "'");
+        LogDebug("Baud Rate: " + BaudRate);
+        LogDebug("Operating System: " + Environment.OSVersion);
+        
         try
         {
+            LogDebug("Opening serial port '" + portName + "'");
             _serialPort.Open();
+            LogDebug("Serial port opened successfully");
+            
             IsReady = true;
+            LogDebug("Starting data loop for serial camera");
             DataLoop();
+            
+            LogDebug("=== SERIAL CAMERA CAPTURE STARTED ===");
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogError(ex, "Failed to start serial camera capture on port '" + portName + "'");
             IsReady = false;
         }
 
         return Task.FromResult(IsReady);
     }
 
+    private void LogDebug(string message)
+    {
+        _logger?.LogInformation(message);
+    }
+
+    private void LogWarning(string message)
+    {
+        _logger?.LogWarning(message);
+    }
+
+    private void LogError(Exception ex, string message)
+    {
+        _logger?.LogError(ex, message);
+    }
+
     private async void DataLoop()
     {
+        LogDebug("Serial camera data loop started");
         byte[] buffer = new byte[2048];
+        int frameCount = 0;
+        
         try
         {
             while (_serialPort.IsOpen)
             {
                 Stream stream = _serialPort.BaseStream;
+                
+                // Read header
                 for (int bufferPosition = 0; bufferPosition < sizeof(ulong);)
                     bufferPosition += await stream.ReadAsync(buffer, bufferPosition, sizeof(ulong) - bufferPosition);
                 ulong header = BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+                
+                // Search for valid header
                 for (; (header & EtvrHeaderMask) != EtvrHeader; header = header >> 8 | (ulong)buffer[0] << 56)
                     while (await stream.ReadAsync(buffer, 0, 1) == 0) /**/;
 
                 ushort jpegSize = (ushort)(header >> BitOperations.TrailingZeroCount(~EtvrHeaderMask));
                 if (buffer.Length < jpegSize)
+                {
+                    LogDebug($"Resizing buffer from {buffer.Length} to {jpegSize} bytes");
                     Array.Resize(ref buffer, jpegSize);
+                }
 
                 BinaryPrimitives.WriteUInt16LittleEndian(buffer, 0xd8ff);
                 for (int bufferPosition = 2; bufferPosition < jpegSize;)
                     bufferPosition += await stream.ReadAsync(buffer, bufferPosition, jpegSize - bufferPosition);
+                
                 var newFrame = Mat.FromImageData(buffer);
                 // Only update the frame count if the image data has actually changed
                 if (newFrame.Width > 0 && newFrame.Height > 0)
                 {
                     newFrame.CopyTo(RawMat);
+                    frameCount++;
+                    
+                    if (frameCount % 100 == 0) // Log every 100 frames
+                    {
+                        LogDebug($"Processed {frameCount} frames from serial camera");
+                    }
+                }
+                else
+                {
+                    LogWarning("Received invalid frame from serial camera (width or height is 0)");
                 }
             }
         }
         catch (ObjectDisposedException)
         {
+            LogWarning("Serial port was disposed - device likely unplugged");
             // Handle when the device is unplugged
             await StopCapture();
             Dispose();
-
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogError(ex, "Error in serial camera data loop");
             await StopCapture();
         }
+        
+        LogDebug($"Serial camera data loop ended after processing {frameCount} frames");
     }
 
     public override Task<bool> StopCapture()
     {
+        LogDebug("Stopping serial camera capture");
         try
         {
             _serialPort.Close();
             IsReady = false;
+            LogDebug("Serial camera capture stopped successfully");
             return Task.FromResult(true);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogError(ex, "Error stopping serial camera capture");
             return Task.FromResult(false);
         }
     }
@@ -111,8 +167,10 @@ public sealed class SerialCameraCapture(string portName) : Capture(portName), ID
 
         if (disposing)
         {
+            LogDebug("Disposing serial camera capture resources");
             StopCapture(); // xlinka 11/8/24: Ensure capture stops before disposing resources
             _serialPort?.Dispose(); // xlinka 11/8/24: Dispose of serial port if initialized
+            LogDebug("Serial camera capture resources disposed");
         }
         _isDisposed = true;
     }

--- a/src/Baballonia.Tests/Baballonia.Tests.csproj
+++ b/src/Baballonia.Tests/Baballonia.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/src/Baballonia.VFTCapture/Baballonia.VFTCapture.csproj
+++ b/src/Baballonia.VFTCapture/Baballonia.VFTCapture.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Baballonia.SDK\Baballonia.SDK.csproj" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Baballonia/Contracts/IInferenceService.cs
+++ b/src/Baballonia/Contracts/IInferenceService.cs
@@ -19,9 +19,9 @@ public interface IInferenceService
 
     public bool GetImage(CameraSettings cameraSettings, out Mat? image);
 
-    public void ConfigurePlatformConnectors(Camera camera, string cameraIndex);
+    public Task ConfigurePlatformConnectors(Camera camera, string cameraIndex);
 
-    public void SetupInference(Camera camera, string cameraAddress);
+    public Task SetupInference(Camera camera, string cameraAddress);
     public SessionOptions SetupSessionOptions();
     public Task ConfigurePlatformSpecificGpu(SessionOptions sessionOptions);
 

--- a/src/Baballonia/Factories/EyeInferenceServiceFactory.cs
+++ b/src/Baballonia/Factories/EyeInferenceServiceFactory.cs
@@ -4,6 +4,7 @@ using Baballonia.Contracts;
 using Baballonia.Services.Inference.Enums;
 using Baballonia.Services.Inference.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Baballonia.Services
 {
@@ -11,27 +12,62 @@ namespace Baballonia.Services
     {
         public static IInferenceService Create(IServiceProvider serviceProvider, Dictionary<Camera, string>? cameraUrls, CameraSettings leftCameraSettings, CameraSettings rightCameraSettings)
         {
-            if (cameraUrls == null) return serviceProvider.GetRequiredService<IDualCameraEyeInferenceService>();
+            var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("Baballonia.Factories.EyeInferenceServiceFactory");
+            
+            logger.LogDebug("Creating eye inference service with camera configuration");
+            logger.LogDebug("Left camera settings: Camera={Camera}, ROI=({X},{Y},{Width},{Height})", 
+                leftCameraSettings.Camera, leftCameraSettings.Roi.X, leftCameraSettings.Roi.Y, 
+                leftCameraSettings.Roi.Width, leftCameraSettings.Roi.Height);
+            logger.LogDebug("Right camera settings: Camera={Camera}, ROI=({X},{Y},{Width},{Height})", 
+                rightCameraSettings.Camera, rightCameraSettings.Roi.X, rightCameraSettings.Roi.Y, 
+                rightCameraSettings.Roi.Width, rightCameraSettings.Roi.Height);
+
+            if (cameraUrls == null) 
+            {
+                logger.LogDebug("Camera URLs dictionary is null, defaulting to DualCameraEyeInferenceService");
+                return serviceProvider.GetRequiredService<IDualCameraEyeInferenceService>();
+            }
 
             var leftCameraUrl = cameraUrls.GetValueOrDefault(Camera.Left);
             var rightCameraUrl = cameraUrls.GetValueOrDefault(Camera.Right);
+            
+            logger.LogDebug("Camera URL resolution: Left='{LeftUrl}', Right='{RightUrl}'", 
+                leftCameraUrl ?? "null", rightCameraUrl ?? "null");
 
             // If either camera URL is not set or if they're the same, use single camera mode
             if (!string.IsNullOrEmpty(leftCameraUrl) && !string.IsNullOrEmpty(rightCameraUrl))
             {
                 if (leftCameraUrl == rightCameraUrl)
                 {
+                    logger.LogDebug("Both cameras use the same URL '{CameraUrl}', selecting SingleCameraEyeInferenceService", leftCameraUrl);
+                    
                     /*var leftRoi = leftCameraSettings.Roi;
                     var rightRoi = rightCameraSettings.Roi;
 
                     if ((leftRoi.X != rightRoi.X || leftRoi.Y != rightRoi.Y ||
                          leftRoi.Width != rightRoi.Width || leftRoi.Height != rightRoi.Height))
                     {
+                        logger.LogDebug("Different ROI configurations detected - Left: ({X1},{Y1},{W1},{H1}), Right: ({X2},{Y2},{W2},{H2})", 
+                            leftRoi.X, leftRoi.Y, leftRoi.Width, leftRoi.Height,
+                            rightRoi.X, rightRoi.Y, rightRoi.Width, rightRoi.Height);
                         return serviceProvider.GetRequiredService<ISingleCameraEyeInferenceService>();
                     }*/
 
                     return serviceProvider.GetRequiredService<ISingleCameraEyeInferenceService>();
                 }
+                else
+                {
+                    logger.LogDebug("Different camera URLs detected, selecting DualCameraEyeInferenceService");
+                }
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(leftCameraUrl))
+                    logger.LogDebug("Left camera URL is empty or null");
+                if (string.IsNullOrEmpty(rightCameraUrl))
+                    logger.LogDebug("Right camera URL is empty or null");
+                logger.LogDebug("Missing camera URL(s), defaulting to DualCameraEyeInferenceService");
             }
 
             return serviceProvider.GetRequiredService<IDualCameraEyeInferenceService>();

--- a/src/Baballonia/LocalSettings.json
+++ b/src/Baballonia/LocalSettings.json
@@ -365,5 +365,6 @@
   "AppSettings_OneEuroMinFreqCutoff": 1,
   "AppSettings_OneEuroSpeedCutoff": 1,
   "AppSettings_UseGPU": true,
-  "AppSettings_CheckForUpdates": false
+  "AppSettings_CheckForUpdates": false,
+  "AppSettings_LogLevel": "Debug"
 }

--- a/src/Baballonia/Services/BaseEyeInferenceService.cs
+++ b/src/Baballonia/Services/BaseEyeInferenceService.cs
@@ -40,9 +40,15 @@ public abstract class BaseEyeInferenceService(ILogger<InferenceService> logger, 
 
     protected bool CaptureFrame(CameraSettings cameraSettings, Mat leftEyeMat, Mat rightEyeMat)
     {
-        if (PlatformConnectors[(int)Camera.Left].Item2?.Capture?.IsReady != true ||
-            PlatformConnectors[(int)Camera.Right].Item2?.Capture?.IsReady != true)
+        var leftReady = PlatformConnectors[(int)Camera.Left].Item2?.Capture?.IsReady == true;
+        var rightReady = PlatformConnectors[(int)Camera.Right].Item2?.Capture?.IsReady == true;
+        
+        if (!leftReady || !rightReady)
         {
+            if (!leftReady)
+                logger.LogDebug("BaseEyeInferenceService: CaptureFrame failed - Left camera is not ready (likely disconnected)");
+            if (!rightReady)
+                logger.LogDebug("BaseEyeInferenceService: CaptureFrame failed - Right camera is not ready (likely disconnected)");
             return false;
         }
 
@@ -89,9 +95,15 @@ public abstract class BaseEyeInferenceService(ILogger<InferenceService> logger, 
 
     protected bool CaptureFrame(CameraSettings leftSetting, CameraSettings rightSettings, Mat leftEyeMat, Mat rightEyeMat)
     {
-        if (PlatformConnectors[(int)Camera.Left].Item2?.Capture?.IsReady != true ||
-            PlatformConnectors[(int)Camera.Right].Item2?.Capture?.IsReady != true)
+        var leftReady = PlatformConnectors[(int)Camera.Left].Item2?.Capture?.IsReady == true;
+        var rightReady = PlatformConnectors[(int)Camera.Right].Item2?.Capture?.IsReady == true;
+        
+        if (!leftReady || !rightReady)
         {
+            if (!leftReady)
+                logger.LogDebug("BaseEyeInferenceService: CaptureFrame (dual-settings) failed - Left camera is not ready (likely disconnected)");
+            if (!rightReady)
+                logger.LogDebug("BaseEyeInferenceService: CaptureFrame (dual-settings) failed - Right camera is not ready (likely disconnected)");
             return false;
         }
 

--- a/src/Baballonia/Services/Inference/CameraController.cs
+++ b/src/Baballonia/Services/Inference/CameraController.cs
@@ -166,13 +166,13 @@ public class CameraController : IDisposable
         return CropManager.CropZone.GetRect();
     }
 
-    public void StartCamera(string cameraAddress)
+    public async Task StartCamera(string cameraAddress)
     {
         if (!string.IsNullOrEmpty(cameraAddress))
         {
             StopCamera();
         }
-        _inferenceService.SetupInference(_camera, cameraAddress);
+        await _inferenceService.SetupInference(_camera, cameraAddress);
     }
 
     public void StopCamera()

--- a/src/Baballonia/Services/Inference/Platforms/PlatformConnector.cs
+++ b/src/Baballonia/Services/Inference/Platforms/PlatformConnector.cs
@@ -79,9 +79,18 @@ public abstract class PlatformConnector
                     foundMatchingCapture = true;
                     Logger.LogDebug("Found matching capture type: {CaptureTypeName}", capture.Value.Name);
                     
+                    try
+                    {
                         Logger.LogDebug("Attempting to create {CaptureTypeName} with logger support", capture.Value.Name);
                         Capture = (Capture)Activator.CreateInstance(capture.Value, url, Logger)!;
                         Logger.LogDebug("Successfully created {CaptureTypeName} with logger", capture.Value.Name);
+                    }
+                    catch (MissingMethodException)
+                    {
+                        Logger.LogDebug("Logger constructor failed, trying with just URL parameter for {CaptureTypeName}", capture.Value.Name);
+                        Capture = (Capture)Activator.CreateInstance(capture.Value, url)!;
+                        Logger.LogDebug("Successfully created {CaptureTypeName} with URL only", capture.Value.Name);
+                    }
                     
                     Logger.LogInformation("Changed capture source to {CaptureTypeName} with url {Url}.", capture.Value.Name, url);
                     break;

--- a/src/Baballonia/Services/LogFile.cs
+++ b/src/Baballonia/Services/LogFile.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 namespace Baballonia.Services;
 
@@ -19,26 +20,64 @@ public class LogFileLogger : ILogger
 
     public IDisposable BeginScope<TState>(TState state) where TState : notnull => default!;
 
-    public bool IsEnabled(LogLevel logLevel) => true;
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        var minLogLevel = GetMinimumLogLevel();
+        return logLevel >= minLogLevel;
+    }
+
+    private static LogLevel GetMinimumLogLevel()
+    {
+        try
+        {
+            var settingsPath = Path.Combine(Utils.PersistentDataDirectory, "ApplicationData", "LocalSettings.json");
+            if (File.Exists(settingsPath))
+            {
+                var json = File.ReadAllText(settingsPath);
+                var settings = JsonSerializer.Deserialize<JsonDocument>(json);
+                
+                if (settings?.RootElement.TryGetProperty("AppSettings_LogLevel", out var logLevelElement) == true)
+                {
+                    var logLevelString = logLevelElement.GetString();
+                    if (Enum.TryParse<LogLevel>(logLevelString, true, out var logLevel)) 
+                    {
+                        return logLevel;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Ignore errors, use default
+        }
+        
+        // Default to Debug level
+        return LogLevel.Debug;
+    }
 
     public void Log<TState>(
         LogLevel logLevel,
         EventId eventId,
         TState state,
         Exception? exception,
-        Func<TState, Exception, string> formatter)
+        Func<TState, Exception?, string> formatter)
     {
+        if (!IsEnabled(logLevel))
+            return;
+            
         Mutex.WaitOne(); // Wait for the semaphore to be released
         try
         {
-            _file.Write($"[{_categoryName}] {logLevel}: {formatter(state, exception!)}\n");
+            _file.Write($"[{_categoryName}] {logLevel}: {formatter(state, exception)}\n");
             _file.Flush();
         }
         catch
         {
             // Ignore cus sandboxing causes a lot of issues here
         }
-
-        Mutex.ReleaseMutex(); // Release the semaphore
+        finally
+        {
+            Mutex.ReleaseMutex(); // Always release the semaphore
+        }
     }
 }

--- a/src/Baballonia/Services/OscRecvService.cs
+++ b/src/Baballonia/Services/OscRecvService.cs
@@ -59,8 +59,11 @@ public class OscRecvService : BackgroundService
 
     public override async Task StartAsync(CancellationToken cancellationToken)
     {
+        _logger.LogInformation("Starting OSC Receive Service...");
         await _settingsService.Load(_oscTarget);
+        _logger.LogDebug("OSC target loaded - Address: {Address}, InPort: {InPort}", _oscTarget.DestinationAddress, _oscTarget.InPort);
         await base.StartAsync(cancellationToken);
+        _logger.LogInformation("OSC Receive Service started successfully");
     }
 
     public IPEndPoint UpdateTarget(IPEndPoint endpoint)
@@ -92,6 +95,7 @@ public class OscRecvService : BackgroundService
 
     protected async override Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        _logger.LogDebug("OSC Receive Service ExecuteAsync started");
         _stoppingToken = stoppingToken;
         _linkedToken = CancellationTokenSource.CreateLinkedTokenSource(_stoppingToken, _cts.Token);
 

--- a/src/Baballonia/Services/ParameterSenderService.cs
+++ b/src/Baballonia/Services/ParameterSenderService.cs
@@ -7,6 +7,7 @@ using Baballonia.Contracts;
 using Baballonia.Helpers;
 using Baballonia.Services.Inference;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using OscCore;
 
 namespace Baballonia.Services;
@@ -14,7 +15,8 @@ namespace Baballonia.Services;
 public class ParameterSenderService(
     OscSendService sendService,
     ILocalSettingsService localSettingsService,
-    ICalibrationService calibrationService) : BackgroundService
+    ICalibrationService calibrationService,
+    ILogger<ParameterSenderService> logger) : BackgroundService
 {
     private readonly Queue<OscMessage> _sendQueue = new();
 
@@ -80,6 +82,10 @@ public class ParameterSenderService(
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
+        logger.LogInformation("Starting Parameter Sender Service...");
+        logger.LogDebug("OSC parameter mapping initialized with {EyeCount} eye expressions and {FaceCount} face expressions", 
+            EyeExpressionMap.Count, FaceExpressionMap.Count);
+        
         while (!cancellationToken.IsCancellationRequested)
         {
             try

--- a/src/Baballonia/ViewModels/SplitViewPane/AppSettingsViewModel.cs
+++ b/src/Baballonia/ViewModels/SplitViewPane/AppSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Baballonia.Contracts;
@@ -19,8 +20,9 @@ public partial class AppSettingsViewModel : ViewModelBase
     [property: SavedSetting("AppSettings_RecalibrateAddress", "/avatar/parameters/etvr_recalibrate")]
     private string _recalibrateAddress;
 
+    // TODO: Verify this was the intended behavior (previously was RecalibrateAddress twice)
     [ObservableProperty]
-    [property: SavedSetting("AppSettings_RecalibrateAddress", "/avatar/parameters/etvr_recenter")]
+    [property: SavedSetting("AppSettings_RecenterAddress", "/avatar/parameters/etvr_recenter")]
     private string _recenterAddress;
 
     [ObservableProperty]
@@ -51,7 +53,19 @@ public partial class AppSettingsViewModel : ViewModelBase
     [property: SavedSetting("AppSettings_CheckForUpdates", false)]
     private bool _checkForUpdates;
 
+    [ObservableProperty]
+    [property: SavedSetting("AppSettings_LogLevel", "Debug")]
+    private string _logLevel;
+
     [ObservableProperty] private bool _onboardingEnabled;
+
+    public List<string> LogLevels { get; } = new List<string> 
+    { 
+        "Debug", 
+        "Information", 
+        "Warning", 
+        "Error" 
+    };
 
     public AppSettingsViewModel()
     {

--- a/src/Baballonia/ViewModels/SplitViewPane/HomePageViewModel.cs
+++ b/src/Baballonia/ViewModels/SplitViewPane/HomePageViewModel.cs
@@ -306,7 +306,7 @@ public partial class HomePageViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        model.Controller.StartCamera(camera);
+        await model.Controller.StartCamera(camera);
 
         if (model.Name != "FaceCamera")
         {
@@ -322,7 +322,7 @@ public partial class HomePageViewModel : ViewModelBase, IDisposable
                             {
                                 if (App.DeviceEnumerator.Cameras!.TryGetValue(RightCamera.DisplayAddress, out var mappedAddress))
                                 {
-                                    _processingLoopService.RightCameraController.StartCamera(mappedAddress);
+                                    await _processingLoopService.RightCameraController.StartCamera(mappedAddress);
                                 }
                             }
                         }
@@ -337,7 +337,7 @@ public partial class HomePageViewModel : ViewModelBase, IDisposable
                             {
                                 if (App.DeviceEnumerator.Cameras!.TryGetValue(LeftCamera.DisplayAddress, out var mappedAddress))
                                 {
-                                    _processingLoopService.LeftCameraController.StartCamera(mappedAddress);
+                                    await _processingLoopService.LeftCameraController.StartCamera(mappedAddress);
                                 }
                             }
                         }

--- a/src/Baballonia/Views/AppSettingsView.axaml
+++ b/src/Baballonia/Views/AppSettingsView.axaml
@@ -40,6 +40,19 @@
                 </controls:SettingsBlock.SettingsContent>
             </controls:SettingsBlock>
 
+            <controls:SettingsBlock
+                Title="Log Level"
+                Description="Set the minimum log level for file logging. Debug shows the most detail."
+                IconPath="DocumentTextRegular">
+                <controls:SettingsBlock.SettingsContent>
+                    <ComboBox 
+                        x:Name="LogLevelCombo" 
+                        VerticalAlignment="Center"
+                        ItemsSource="{Binding LogLevels}"
+                        SelectedItem="{Binding LogLevel}" />
+                </controls:SettingsBlock.SettingsContent>
+            </controls:SettingsBlock>
+
             <Expander
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"

--- a/src/Baballonia/Views/AppSettingsView.axaml.cs
+++ b/src/Baballonia/Views/AppSettingsView.axaml.cs
@@ -17,6 +17,7 @@ public partial class AppSettingsView : UserControl
     private readonly IMainService _mainService;
     private readonly ComboBox _themeComboBox;
     private readonly ComboBox _langComboBox;
+    private readonly ComboBox _logLevelComboBox;
     private readonly ComboBox _selectedMinFreqCutoffComboBox;
     private readonly ComboBox _selectedSpeedCutoffComboxBox;
     private readonly NumericUpDown _selectedMinFreqCutoffUpDown;
@@ -33,6 +34,9 @@ public partial class AppSettingsView : UserControl
         _languageSelectorService = Ioc.Default.GetService<ILanguageSelectorService>()!;
         _langComboBox = this.Find<ComboBox>("LangCombo")!;
         _langComboBox.SelectionChanged += LangComboBox_SelectionChanged;
+
+        _logLevelComboBox = this.Find<ComboBox>("LogLevelCombo")!;
+        _logLevelComboBox.SelectionChanged += LogLevelComboBox_SelectionChanged;
 
         _selectedMinFreqCutoffComboBox = this.Find<ComboBox>("SelectedMinFreqCutoffComboBox")!;
         _selectedSpeedCutoffComboxBox = this.Find<ComboBox>("SelectedSpeedCutoffComboBox")!;
@@ -105,6 +109,12 @@ public partial class AppSettingsView : UserControl
         {
             await _languageSelectorService.SetLanguageAsync(item!.Name!);
         });
+    }
+
+    private void LogLevelComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        // The log level setting is automatically saved through the ViewModel binding
+        // No additional action needed here since the LogFileLogger reads from settings
     }
 
     // Workaround for https://github.com/AvaloniaUI/Avalonia/issues/4460


### PR DESCRIPTION
Adds debug or information-level logging to:
* DesktopDeviceEnumerator
* OpenCvCapture
* EyeInferenceServiceFactory
* BaseEyeInferenceService
* DualCameraEyeInferenceService
* FaceInferenceService
* PlatformConnector (redirects a console.writeline to the logs as LogError)
* InferenceService
* OscRecvService
* ParameterSenderService
* SingleCameraEyeInferenceService 

Also:
* On startup in App.axaml.cs it tests and logs device enumeration
* Sets default Debug log level in LocalSettings.json  
* Makes StartCamera async in CameraController
* Makes Initialize async in PlatformConnector
* Makes SetupInference and ConfigurePlatformConnectors async in InferenceService
* Surrounds ConfigurePlatformConnectors logic with try/catch
* Rotates latest.log to old.log on start; rotates old.log to older.log on start
* Checks for onnx model in both the absolute path and relative to the executable 
* HomePageViewModel now awaits StartCamera
* New dropdown for log level (default Debug)

**Outstanding question:**
In AppSettingsViewModel.cs note the change on line 25 from 
```
    [property: SavedSetting("AppSettings_RecalibrateAddress", "/avatar/parameters/etvr_recenter")]
```
to
```
    [property: SavedSetting("AppSettings_RecenterAddress", "/avatar/parameters/etvr_recenter")]
    private string _recenter
```
Was this the intended behavior?