### PR TITLE
Fix crash due to a race condition in HomePageViewModel and HomePageView

### DIFF
--- a/src/Baballonia/ViewModels/SplitViewPane/HomePageViewModel.cs
+++ b/src/Baballonia/ViewModels/SplitViewPane/HomePageViewModel.cs
@@ -397,6 +397,7 @@ public partial class HomePageViewModel : ViewModelBase, IDisposable
     [ObservableProperty] private CameraControllerModel _leftCamera;
     [ObservableProperty] private CameraControllerModel _rightCamera;
     [ObservableProperty] private CameraControllerModel _faceCamera;
+    public readonly TaskCompletionSource camerasInitialized = new();
 
     private readonly DispatcherTimer _msgCounterTimer;
     private readonly ILocalSettingsService _localSettingsService;
@@ -444,6 +445,7 @@ public partial class HomePageViewModel : ViewModelBase, IDisposable
                 _processingLoopService.EyesProcessingPipeline, cameraNames, Camera.Right);
             FaceCamera = new CameraControllerModel(_localSettingsService, "FaceCamera",
                 _processingLoopService.FaceProcessingPipeline, cameraNames, Camera.Face);
+            camerasInitialized.SetResult();
         });
 
         _processingLoopService.PipelineExceptionEvent += PipelineExceptionEventHandler;

--- a/src/Baballonia/Views/HomePageView.axaml.cs
+++ b/src/Baballonia/Views/HomePageView.axaml.cs
@@ -92,9 +92,10 @@ public partial class HomePageView : UserControl
                 }
             };
         }
-        Loaded += (_, _) =>
+        Loaded += async (_, _) =>
         {
             if (DataContext is not HomePageViewModel vm) return;
+            await vm.camerasInitialized.Task;
 
             SetupCropEvents(vm.LeftCamera, LeftMouthWindow);
             SetupCropEvents(vm.RightCamera, RightMouthWindow);
@@ -136,7 +137,7 @@ public partial class HomePageView : UserControl
     private void EyeAddressEntry_OnTextChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (e is null) return; // Skip DeviceEnumerator calls
-        if (DataContext is not HomePageViewModel vm) return;
+        if (DataContext is not HomePageViewModel vm || vm.FaceCamera == null) return;
 
         if (string.IsNullOrEmpty(vm.LeftCamera.DisplayAddress) ||
             string.IsNullOrEmpty(vm.RightCamera.DisplayAddress)) return;


### PR DESCRIPTION
HomePageView was trying to access the cameras while they were still initializing in HomePageViewModel.
This exception only happened when a camera was already started.