### PR TITLE
fix: insert cameras with identical names on windows

### DIFF
--- a/src/Baballonia.Desktop/DesktopDeviceEnumerator.cs
+++ b/src/Baballonia.Desktop/DesktopDeviceEnumerator.cs
@@ -111,8 +111,9 @@ public sealed class DesktopDeviceEnumerator(ILogger<DesktopDeviceEnumerator> log
 
         for (var index = 0; index < videoInputDevices.Length; index++)
         {
-            var device = videoInputDevices[index];
-            cameraDict.Add(device.Name, index.ToString());
+            var dev = videoInputDevices[index];
+            logger.LogInformation("Found device: {}, ClassId: {}, Path: {}", dev.Name, dev.ClassID, dev.DevicePath);
+            EnsureUniqueKey(cameraDict, dev.Name, index.ToString());
         }
         #endif
     }


### PR DESCRIPTION
https://github.com/Project-Babble/Baballonia/issues/55