### PR TITLE
Add Eye Stabilization (Averaging + Convergence Offset) toggle to improve stability

### DIFF
--- a/src/Baballonia.Desktop/Baballonia.Desktop.csproj
+++ b/src/Baballonia.Desktop/Baballonia.Desktop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
@@ -43,13 +43,14 @@
         <!-- Linux-specific -->
         <PackageReference Include="Sdcb.OpenCvSharp4.mini.runtime.linux-x64" Version="4.11.0.35" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
 	    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-      <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))"/>
+      <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Baballonia.OpenCVCapture\Baballonia.OpenCVCapture.csproj"/>
+        <ProjectReference Include="..\Baballonia.OpenCVCapture\Baballonia.OpenCVCapture.csproj" />
         <ProjectReference Include="..\Baballonia.SDK\Baballonia.SDK.csproj" />
-        <ProjectReference Include="..\Baballonia.SerialCameraCapture\Baballonia.SerialCameraCapture.csproj"/>
+        <ProjectReference Include="..\Baballonia.SerialCameraCapture\Baballonia.SerialCameraCapture.csproj" />
         <ProjectReference Include="..\Baballonia\Baballonia.csproj" />
+        <ProjectReference Include="..\VRCFaceTracking.Baballonia\VRCFaceTracking.Baballonia.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -172,21 +173,13 @@
           <ExtractToPath>$(OutputPath)_internal</ExtractToPath>
       </PropertyGroup>
 
-      <Message Text="Extracting $(ZipFilePath) to $(ExtractToPath)"
-               Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')"
-               Importance="high" />
+      <Message Text="Extracting $(ZipFilePath) to $(ExtractToPath)" Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')" Importance="high" />
 
-      <Unzip SourceFiles="$(ZipFilePath)"
-             DestinationFolder="$(ExtractToPath)"
-             Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')"
-             OverwriteReadOnlyFiles="true" />
+      <Unzip SourceFiles="$(ZipFilePath)" DestinationFolder="$(ExtractToPath)" Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')" OverwriteReadOnlyFiles="true" />
 
-      <Message Text="Extraction folder already exists: $(ExtractToPath)"
-               Condition="Exists('$(ExtractToPath)')"
-               Importance="normal" />
+      <Message Text="Extraction folder already exists: $(ExtractToPath)" Condition="Exists('$(ExtractToPath)')" Importance="normal" />
 
-      <Warning Text="Zip file not found: $(ZipFilePath)"
-               Condition="!Exists('$(ZipFilePath)')" />
+      <Warning Text="Zip file not found: $(ZipFilePath)" Condition="!Exists('$(ZipFilePath)')" />
   </Target>
 
 </Project>

--- a/src/Baballonia.Desktop/Baballonia.Desktop.csproj
+++ b/src/Baballonia.Desktop/Baballonia.Desktop.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
@@ -43,14 +43,13 @@
         <!-- Linux-specific -->
         <PackageReference Include="Sdcb.OpenCvSharp4.mini.runtime.linux-x64" Version="4.11.0.35" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
 	    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-      <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+      <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Baballonia.OpenCVCapture\Baballonia.OpenCVCapture.csproj" />
+        <ProjectReference Include="..\Baballonia.OpenCVCapture\Baballonia.OpenCVCapture.csproj"/>
         <ProjectReference Include="..\Baballonia.SDK\Baballonia.SDK.csproj" />
-        <ProjectReference Include="..\Baballonia.SerialCameraCapture\Baballonia.SerialCameraCapture.csproj" />
+        <ProjectReference Include="..\Baballonia.SerialCameraCapture\Baballonia.SerialCameraCapture.csproj"/>
         <ProjectReference Include="..\Baballonia\Baballonia.csproj" />
-        <ProjectReference Include="..\VRCFaceTracking.Baballonia\VRCFaceTracking.Baballonia.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -173,13 +172,22 @@
           <ExtractToPath>$(OutputPath)_internal</ExtractToPath>
       </PropertyGroup>
 
-      <Message Text="Extracting $(ZipFilePath) to $(ExtractToPath)" Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')" Importance="high" />
+      <Message Text="Extracting $(ZipFilePath) to $(ExtractToPath)"
+               Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')"
+               Importance="high" />
 
-      <Unzip SourceFiles="$(ZipFilePath)" DestinationFolder="$(ExtractToPath)" Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')" OverwriteReadOnlyFiles="true" />
+      <Unzip SourceFiles="$(ZipFilePath)"
+             DestinationFolder="$(ExtractToPath)"
+             Condition="Exists('$(ZipFilePath)') AND !Exists('$(ExtractToPath)')"
+             OverwriteReadOnlyFiles="true" />
 
-      <Message Text="Extraction folder already exists: $(ExtractToPath)" Condition="Exists('$(ExtractToPath)')" Importance="normal" />
+      <Message Text="Extraction folder already exists: $(ExtractToPath)"
+               Condition="Exists('$(ExtractToPath)')"
+               Importance="normal" />
 
-      <Warning Text="Zip file not found: $(ZipFilePath)" Condition="!Exists('$(ZipFilePath)')" />
+      <Warning Text="Zip file not found: $(ZipFilePath)"
+               Condition="!Exists('$(ZipFilePath)')" />
   </Target>
 
 </Project>
+

--- a/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
+++ b/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
@@ -13,9 +13,6 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
     private readonly ImageCollector _imageCollector = new();
     public bool StabilizeEyes { get; set; } = false;
 
-    public EyeProcessingPipeline(){
-    }
-
     public float[]? RunUpdate()
     {
         var frame = VideoSource?.GetFrame(ColorType.Gray8);

--- a/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
+++ b/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
@@ -17,8 +17,6 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
 
     public EyeProcessingPipeline()
     {
-        // The original constructor body is removed as per the edit hint.
-        // The LoadEyeStabilizationSetting() call is also removed.
     }
 
     public float[]? RunUpdate()
@@ -65,7 +63,6 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         return inferenceResult;
     }
 
-    // Keep the method synchronous
     private bool ProcessExpressions(ref float[] arKitExpressions)
     {
         if (arKitExpressions.Length < Utils.EyeRawExpressions)
@@ -82,27 +79,22 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         var rightYaw = arKitExpressions[4] * mulV - mulV / 2;
         var rightLid = 1 - arKitExpressions[5];
 
-        // Use the property instead of async call
         if (StabilizeEyes)
         {
-            // Calculate convergence before averaging
-            // Clamp convergence to never go below 0 (no wall-eyed behavior)
+            // Clamp convergence to never go below 0 (no wall-eyed behavior. We do this because it's entirely possible to have the model output give your eyes divergence)
             var rawConvergence = (leftYaw - rightYaw) / 2.0f;
             var convergence = Math.Max(0, rawConvergence);
             
-            // Calculate averaged eye positions
             var averagedPitch = (leftPitch + rightPitch) / 2.0f;
             var averagedYaw = (leftYaw + rightYaw) / 2.0f;
             
-            // Apply convergence back to the averaged positions
             var leftYawWithConvergence = averagedYaw + convergence;
             var rightYawWithConvergence = averagedYaw - convergence;
 
-            // Update the expressions with stabilized values
-            arKitExpressions[0] = averagedPitch;              // left pitch (averaged)
-            arKitExpressions[1] = leftYawWithConvergence;     // left yaw (averaged + convergence)
-            arKitExpressions[3] = averagedPitch;              // right pitch (averaged)
-            arKitExpressions[4] = rightYawWithConvergence;    // right yaw (averaged - convergence)
+            arKitExpressions[0] = averagedPitch;
+            arKitExpressions[1] = leftYawWithConvergence;
+            arKitExpressions[3] = averagedPitch;
+            arKitExpressions[4] = rightYawWithConvergence;
         }
 
         var eyeY = (leftPitch * leftLid + rightPitch * rightLid) / (leftLid + rightLid);

--- a/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
+++ b/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
@@ -95,7 +95,7 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         // [left pitch, left yaw, left lid...
         float[] convertedExpressions = new float[Utils.EyeRawExpressions];
 
-        // swap eyes at this point                            ↓ this is abysmal
+        // swap eyes at this point
         convertedExpressions[0] = rightEyeYawCorrected; // left pitch 
         convertedExpressions[1] = eyeY;                   // left yaw
         convertedExpressions[2] = rightLid;               // left lid

--- a/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
+++ b/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
@@ -79,34 +79,27 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         var rightYaw = arKitExpressions[4] * mulV - mulV / 2;
         var rightLid = 1 - arKitExpressions[5];
 
-        if (StabilizeEyes)
-        {
-            // Clamp convergence to never go below 0 (no wall-eyed behavior. We do this because it's entirely possible to have the model output give your eyes divergence)
-            var rawConvergence = (leftYaw - rightYaw) / 2.0f;
-            var convergence = Math.Max(0, rawConvergence);
-            
-            var averagedPitch = (leftPitch + rightPitch) / 2.0f;
-            var averagedYaw = (leftYaw + rightYaw) / 2.0f;
-            
-            var leftYawWithConvergence = averagedYaw + convergence;
-            var rightYawWithConvergence = averagedYaw - convergence;
-
-            arKitExpressions[0] = averagedPitch;
-            arKitExpressions[1] = leftYawWithConvergence;
-            arKitExpressions[3] = averagedPitch;
-            arKitExpressions[4] = rightYawWithConvergence;
-        }
-
         var eyeY = (leftPitch * leftLid + rightPitch * rightLid) / (leftLid + rightLid);
 
         var leftEyeYawCorrected = rightYaw * (1 - leftLid) + leftYaw * leftLid;
         var rightEyeYawCorrected = leftYaw * (1 - rightLid) + rightYaw * rightLid;
 
+        if (StabilizeEyes)
+        {
+            var rawConvergence = (rightEyeYawCorrected - leftEyeYawCorrected) / 2.0f;
+            var convergence = Math.Max(rawConvergence, 0.0f);
+
+            var averagedYaw = (rightEyeYawCorrected + leftEyeYawCorrected) / 2.0f;
+
+            leftEyeYawCorrected = averagedYaw - convergence;
+            rightEyeYawCorrected = averagedYaw + convergence;
+        }
+
         // [left pitch, left yaw, left lid...
         float[] convertedExpressions = new float[Utils.EyeRawExpressions];
 
         // swap eyes at this point
-        convertedExpressions[0] = rightEyeYawCorrected; // left pitch
+        convertedExpressions[0] = rightEyeYawCorrected; // left pitch (what the fuck are you doing here why are these comments like this none of this makes any sense - Ridge)
         convertedExpressions[1] = eyeY;                   // left yaw
         convertedExpressions[2] = rightLid;               // left lid
         convertedExpressions[3] = leftEyeYawCorrected;  // right pitch

--- a/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
+++ b/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
@@ -11,12 +11,9 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
 {
     private readonly FastCorruptionDetector _fastCorruptionDetector = new();
     private readonly ImageCollector _imageCollector = new();
-    
-    // Add a property to control stabilization
     public bool StabilizeEyes { get; set; } = false;
 
-    public EyeProcessingPipeline()
-    {
+    public EyeProcessingPipeline(){
     }
 
     public float[]? RunUpdate()
@@ -87,7 +84,7 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         if (StabilizeEyes)
         {
             var rawConvergence = (rightEyeYawCorrected - leftEyeYawCorrected) / 2.0f;
-            var convergence = Math.Max(rawConvergence, 0.0f);
+            var convergence = Math.Max(rawConvergence, 0.0f); //We clamp the value here to avoid accidental divergence, as the model sometimes decides that's a thing
 
             var averagedYaw = (rightEyeYawCorrected + leftEyeYawCorrected) / 2.0f;
 
@@ -98,8 +95,8 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         // [left pitch, left yaw, left lid...
         float[] convertedExpressions = new float[Utils.EyeRawExpressions];
 
-        // swap eyes at this point
-        convertedExpressions[0] = rightEyeYawCorrected; // left pitch (what the fuck are you doing here why are these comments like this none of this makes any sense - Ridge)
+        // swap eyes at this point                            ↓ this is abysmal
+        convertedExpressions[0] = rightEyeYawCorrected; // left pitch 
         convertedExpressions[1] = eyeY;                   // left yaw
         convertedExpressions[2] = rightLid;               // left lid
         convertedExpressions[3] = leftEyeYawCorrected;  // right pitch

--- a/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
+++ b/src/Baballonia/Services/Inference/EyeProcessingPipeline.cs
@@ -79,24 +79,6 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         var rightYaw = arKitExpressions[4] * mulV - mulV / 2;
         var rightLid = 1 - arKitExpressions[5];
 
-        if (StabilizeEyes)
-        {
-            // Clamp convergence to never go below 0 (no wall-eyed behavior. We do this because it's entirely possible to have the model output give your eyes divergence)
-            var rawConvergence = (leftYaw - rightYaw) / 2.0f;
-            var convergence = Math.Max(0, rawConvergence);
-            
-            var averagedPitch = (leftPitch + rightPitch) / 2.0f;
-            var averagedYaw = (leftYaw + rightYaw) / 2.0f;
-            
-            var leftYawWithConvergence = averagedYaw + convergence;
-            var rightYawWithConvergence = averagedYaw - convergence;
-
-            arKitExpressions[0] = averagedPitch;
-            arKitExpressions[1] = leftYawWithConvergence;
-            arKitExpressions[3] = averagedPitch;
-            arKitExpressions[4] = rightYawWithConvergence;
-        }
-
         var eyeY = (leftPitch * leftLid + rightPitch * rightLid) / (leftLid + rightLid);
 
         var leftEyeYawCorrected = rightYaw * (1 - leftLid) + leftYaw * leftLid;
@@ -112,6 +94,34 @@ public class EyeProcessingPipeline : DefaultProcessingPipeline
         convertedExpressions[3] = leftEyeYawCorrected;  // right pitch
         convertedExpressions[4] = eyeY;                   // right yaw
         convertedExpressions[5] = leftLid;                // right lid
+
+        // NOW apply stabilization to the converted expressions
+        if (StabilizeEyes)
+        {
+            // Calculate convergence from the converted expressions
+            var leftPitchStable = convertedExpressions[0];
+            var leftYawStable = convertedExpressions[1];
+            var rightPitchStable = convertedExpressions[3];
+            var rightYawStable = convertedExpressions[4];
+
+            // Calculate convergence before averaging
+            var rawConvergence = (leftYawStable - rightYawStable) / 2.0f;
+            var convergence = Math.Max(0, rawConvergence);
+            
+            // Calculate averaged eye positions
+            var averagedPitch = (leftPitchStable + rightPitchStable) / 2.0f;
+            var averagedYaw = (leftYawStable + rightYawStable) / 2.0f;
+            
+            // Apply convergence back to the averaged positions
+            var leftYawWithConvergence = averagedYaw + convergence;
+            var rightYawWithConvergence = averagedYaw - convergence;
+
+            // Update the converted expressions with stabilized values
+            convertedExpressions[0] = averagedPitch;              // left pitch (averaged)
+            convertedExpressions[1] = leftYawWithConvergence;     // left yaw (averaged + convergence)
+            convertedExpressions[3] = averagedPitch;              // right pitch (averaged)
+            convertedExpressions[4] = rightYawWithConvergence;    // right yaw (averaged - convergence)
+        }
 
         arKitExpressions = convertedExpressions;
 

--- a/src/Baballonia/Services/ProcessingLoopService.cs
+++ b/src/Baballonia/Services/ProcessingLoopService.cs
@@ -55,7 +55,7 @@ public class ProcessingLoopService : IDisposable
         _ = SetupFaceInference();
         _ = SetupEyeInference();
         _ = LoadFilters();
-        _ = LoadEyeStabilizationSetting(); // Add this call!
+        _ = LoadEyeStabilizationSetting();
 
         _drawTimer.Tick += TimerEvent;
         _drawTimer.Start();

--- a/src/Baballonia/Services/ProcessingLoopService.cs
+++ b/src/Baballonia/Services/ProcessingLoopService.cs
@@ -41,7 +41,10 @@ public class ProcessingLoopService : IDisposable
 
         FaceProcessingPipeline.ImageConverter = new MatToFloatTensorConverter();
         FaceProcessingPipeline.ImageTransformer = new ImageTransformer();
+ 
+        EyesProcessingPipeline = new EyeProcessingPipeline();
         EyesProcessingPipeline.ImageConverter = new MatToFloatTensorConverter();
+        
         var dualTransformer = new DualImageTransformer();
         dualTransformer.LeftTransformer.TargetSize = new Size(128, 128);
         dualTransformer.RightTransformer.TargetSize = new Size(128, 128);
@@ -50,6 +53,7 @@ public class ProcessingLoopService : IDisposable
         _ = SetupFaceInference();
         _ = SetupEyeInference();
         _ = LoadFilters();
+        _ = LoadEyeStabilizationSetting(); // Add this call!
 
         _drawTimer.Tick += TimerEvent;
         _drawTimer.Start();
@@ -118,6 +122,12 @@ public class ProcessingLoopService : IDisposable
 
             Dispatcher.UIThread.Post(() => { FaceProcessingPipeline.InferenceService = faceInference; });
         });
+    }
+
+    private async Task LoadEyeStabilizationSetting()
+    {
+        var stabilizeEyes = await _localSettingsService.ReadSettingAsync<bool>("AppSettings_StabilizeEyes", false);
+        EyesProcessingPipeline.StabilizeEyes = stabilizeEyes;
     }
 
     private void TimerEvent(object? s, EventArgs e)

--- a/src/Baballonia/Services/ProcessingLoopService.cs
+++ b/src/Baballonia/Services/ProcessingLoopService.cs
@@ -44,7 +44,6 @@ public class ProcessingLoopService : IDisposable
         FaceProcessingPipeline.ImageConverter = new MatToFloatTensorConverter();
         FaceProcessingPipeline.ImageTransformer = new ImageTransformer();
  
-        EyesProcessingPipeline = new EyeProcessingPipeline();
         EyesProcessingPipeline.ImageConverter = new MatToFloatTensorConverter();
         
         var dualTransformer = new DualImageTransformer();

--- a/src/Baballonia/ViewModels/SplitViewPane/CalibrationViewModel.cs
+++ b/src/Baballonia/ViewModels/SplitViewPane/CalibrationViewModel.cs
@@ -149,13 +149,11 @@ public partial class CalibrationViewModel : ViewModelBase, IDisposable
         LoadInitialSettings();
         _settingsService.Load(this);
         
-        // Add property change handler for StabilizeEyes
         PropertyChanged += async (o, p) =>
         {
             if (p.PropertyName == nameof(StabilizeEyes))
             {
                 await _settingsService.SaveSettingAsync("AppSettings_StabilizeEyes", StabilizeEyes);
-                // Update the pipeline immediately
                 _processingLoopService.EyesProcessingPipeline.StabilizeEyes = StabilizeEyes;
             }
         };

--- a/src/Baballonia/ViewModels/SplitViewPane/CalibrationViewModel.cs
+++ b/src/Baballonia/ViewModels/SplitViewPane/CalibrationViewModel.cs
@@ -23,6 +23,10 @@ public partial class CalibrationViewModel : ViewModelBase, IDisposable
     public ObservableCollection<SliderBindableSetting> NoseSettings { get; set; }
     public ObservableCollection<SliderBindableSetting> CheekSettings { get; set; }
 
+    [ObservableProperty]
+    [property: SavedSetting("AppSettings_StabilizeEyes", false)]
+    private bool _stabilizeEyes;
+
     private ILocalSettingsService _settingsService { get; }
     private readonly ICalibrationService _calibrationService;
     private readonly ParameterSenderService _parameterSenderService;
@@ -143,6 +147,18 @@ public partial class CalibrationViewModel : ViewModelBase, IDisposable
         _processingLoopService.ExpressionChangeEvent += ExpressionUpdateHandler;
 
         LoadInitialSettings();
+        _settingsService.Load(this);
+        
+        // Add property change handler for StabilizeEyes
+        PropertyChanged += async (o, p) =>
+        {
+            if (p.PropertyName == nameof(StabilizeEyes))
+            {
+                await _settingsService.SaveSettingAsync("AppSettings_StabilizeEyes", StabilizeEyes);
+                // Update the pipeline immediately
+                _processingLoopService.EyesProcessingPipeline.StabilizeEyes = StabilizeEyes;
+            }
+        };
     }
 
     private void ExpressionUpdateHandler(ProcessingLoopService.Expressions expressions)

--- a/src/Baballonia/Views/CalibrationView.axaml
+++ b/src/Baballonia/Views/CalibrationView.axaml
@@ -60,26 +60,19 @@
           <TextBlock FontWeight="SemiBold" Text="Eye Expressions" />
         </Expander.Header>
         <StackPanel Margin="0,5">
-          <!-- Add the Stabilize Eyes checkbox at the top -->
-          <Border
-            Margin="0,0,0,8"
-            Padding="16"
-            Background="{DynamicResource SystemChromeMediumLowColor}"
-            CornerRadius="8">
-            <Grid>
-              <StackPanel>
-                <TextBlock Margin="0,0,10,0" VerticalAlignment="Center">
-                  <Run FontWeight="SemiBold" Text="Stabilize Eyes" />
-                  <Run Text=" - Averages left and right eye positions, with a convergence offset" />
-                </TextBlock>
-                <CheckBox
-                  IsChecked="{Binding StabilizeEyes, Mode=TwoWay}"
-                  Content="Enable eye position stabilization" />
-              </StackPanel>
-            </Grid>
+
+          <Border Background="{DynamicResource SystemChromeMediumLowColor}" CornerRadius="6" Padding="12" Margin="0,4">
+            <StackPanel Spacing="8">
+              <Grid ColumnDefinitions="*,Auto">
+                <StackPanel Grid.Column="0">
+                  <TextBlock Text="Stabilize Eyes" FontWeight="SemiBold"/>
+                  <TextBlock Text="Averages eye position, but preserves convergence" FontSize="12" Foreground="{DynamicResource SystemBaseMediumColor}"/>
+                </StackPanel>
+                <CheckBox Grid.Column="1" VerticalAlignment="Center" IsChecked="{Binding StabilizeEyes, Mode=TwoWay}"/>
+              </Grid>
+            </StackPanel>
           </Border>
           
-          <!-- Existing eye settings -->
           <ItemsControl ItemsSource="{Binding EyeSettings}">
             <ItemsControl.ItemTemplate>
               <DataTemplate x:DataType="models:SliderBindableSetting">

--- a/src/Baballonia/Views/CalibrationView.axaml
+++ b/src/Baballonia/Views/CalibrationView.axaml
@@ -60,6 +60,26 @@
           <TextBlock FontWeight="SemiBold" Text="Eye Expressions" />
         </Expander.Header>
         <StackPanel Margin="0,5">
+          <!-- Add the Stabilize Eyes checkbox at the top -->
+          <Border
+            Margin="0,0,0,8"
+            Padding="16"
+            Background="{DynamicResource SystemChromeMediumLowColor}"
+            CornerRadius="8">
+            <Grid>
+              <StackPanel>
+                <TextBlock Margin="0,0,10,0" VerticalAlignment="Center">
+                  <Run FontWeight="SemiBold" Text="Stabilize Eyes" />
+                  <Run Text=" - Averages left and right eye positions, with a convergence offset" />
+                </TextBlock>
+                <CheckBox
+                  IsChecked="{Binding StabilizeEyes, Mode=TwoWay}"
+                  Content="Enable eye position stabilization" />
+              </StackPanel>
+            </Grid>
+          </Border>
+          
+          <!-- Existing eye settings -->
           <ItemsControl ItemsSource="{Binding EyeSettings}">
             <ItemsControl.ItemTemplate>
               <DataTemplate x:DataType="models:SliderBindableSetting">


### PR DESCRIPTION
Wrote this because the model output would often cause my eyes to diverge. This addition adds a toggle to average the eyes and add a convergence offset, so each eye can influence the other, rather than sending each eye fully independently. This reduces jitter quite a bit and improves stability, and also gets rid of accidental eye divergence.