### PR TITLE
Update desktop shortcut path

### DIFF
--- a/src/Baballonia.Desktop/main.nsi
+++ b/src/Baballonia.Desktop/main.nsi
@@ -74,7 +74,7 @@
 ; Section - Shortcut
 
   Section "Desktop Shortcut" DeskShort
-    CreateShortCut "$DESKTOP\${NAME}.lnk" "$INSTDIR\${APPFILE}"
+    CreateShortCut "$DESKTOP\${NAME}.lnk" "$INSTDIR\win-x64\${APPFILE}"
   SectionEnd
 
 ;--------------------------------


### PR DESCRIPTION
After the move to GHA, looks like the desktop shortcut NSIS creates is pointing at the wrong path.

`$INSTDIR\${APPFILE}` resolves to `%LOCALAPPDATA%\Baballonia\Baballonia.Desktop.exe`, however the executable is now at `%LOCALAPPDATA%\Baballonia\win-x64\Baballonia.Desktop.exe`.

Quick fix similar to #86 to point things at the right place.