### PR TITLE
Unify warning layout(s)

### DIFF
--- a/src/Baballonia/Views/AppSettingsView.axaml
+++ b/src/Baballonia/Views/AppSettingsView.axaml
@@ -96,10 +96,28 @@
           </Grid>
         </Expander.Header>
         <StackPanel Spacing="12">
-          <TextBlock
-            FontStyle="Italic"
-            TextWrapping="Wrap"
-            Text="{x:Static assets:Resources.Settings_OSC_VRCFT_Warning}" />
+          <Border
+            Background="Orange"
+            CornerRadius="8"
+            Padding="16,12">
+            <Grid ColumnDefinitions="Auto,12,*">
+              <PathIcon
+                Grid.Column="0"
+                Data="{StaticResource WarningRegular}"
+                Foreground="Black"
+                Height="20"
+                Width="20" />
+              <StackPanel Grid.Column="2" Spacing="4">
+                <TextBlock
+                  FontSize="14"
+                  FontWeight="DemiBold"
+                  Foreground="Black"
+                  Text="{x:Static assets:Resources.Settings_OSC_VRCFT_Warning}"
+                  TextWrapping="Wrap" />
+              </StackPanel>
+            </Grid>
+          </Border>
+
           <Grid
               Margin="0,4"
               ColumnDefinitions="Auto,*,Auto"

--- a/src/Baballonia/Views/FirmwareView.axaml
+++ b/src/Baballonia/Views/FirmwareView.axaml
@@ -213,12 +213,28 @@
                     </Grid>
                 </Expander.Header>
                 <StackPanel Spacing="24">
-                  <TextBlock
-                    TextWrapping="Wrap"
-                    FontWeight="ExtraBold"
-                    Text="{x:Static assets:Resources.Firmware_Flashing_Warning}" />
 
-                  <Separator/>
+                  <Border
+                    Background="Orange"
+                    CornerRadius="8"
+                    Padding="16,12">
+                    <Grid ColumnDefinitions="Auto,12,*">
+                      <PathIcon
+                        Grid.Column="0"
+                        Data="{StaticResource WarningRegular}"
+                        Foreground="Black"
+                        Height="20"
+                        Width="20" />
+                      <StackPanel Grid.Column="2" Spacing="4">
+                        <TextBlock
+                          FontSize="14"
+                          FontWeight="DemiBold"
+                          Foreground="Black"
+                          Text="{x:Static assets:Resources.Firmware_Flashing_Warning}"
+                          TextWrapping="Wrap" />
+                      </StackPanel>
+                    </Grid>
+                  </Border>
 
                   <Grid ColumnDefinitions="*,Auto">
                     <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Resources.Firmware_Type_To_Flash}" />

--- a/src/Baballonia/Views/HomePageView.axaml
+++ b/src/Baballonia/Views/HomePageView.axaml
@@ -78,6 +78,7 @@
                       FontSize="16"
                       FontWeight="SemiBold"
                       Foreground="Black"
+                      TextWrapping="Wrap"
                       Text="{x:Static assets:Resources.AdminWarning_Header}" />
                   <TextBlock
                       FontSize="14"


### PR DESCRIPTION
Before:
<img width="1100" height="857" alt="image" src="https://github.com/user-attachments/assets/da96771e-8c12-4052-b496-876f6213a6d3" />

<img width="1100" height="857" alt="image" src="https://github.com/user-attachments/assets/22a0c173-429a-4cdd-b69f-edffc83b1ec5" />

After:

<img width="1100" height="857" alt="image" src="https://github.com/user-attachments/assets/abe53e33-5a23-4bd0-a28b-8ba1a319a999" />

<img width="1100" height="857" alt="image" src="https://github.com/user-attachments/assets/32a54d33-903e-45f4-b42b-3656bc60dfbf" />
