### PR TITLE
nix: Move capture methods to modules folder

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,16 @@
         '';
 
         postFixup = ''
+          mkdir -p $out/lib/baballonia/Modules
           mv $out/bin/Baballonia.Desktop $out/bin/baballonia
+          mv $out/lib/baballonia/Baballonia.VFTCapture.dll $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.VFTCapture.pdb $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.OpenCVCapture.dll $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.OpenCVCapture.pdb $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.IPCameraCapture.dll $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.IPCameraCapture.pdb $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.SerialCameraCapture.dll $out/lib/baballonia/Modules/
+          mv $out/lib/baballonia/Baballonia.SerialCameraCapture.pdb $out/lib/baballonia/Modules/
         '';
 
         meta = with pkgs.lib; {


### PR DESCRIPTION
The nix flake isnt respecting postbuild targets so we need to manually move the capture methods to the `Modules` dir as a postFixup process.