### PR TITLE
feat: Set default language to local language

### DIFF
--- a/src/Baballonia/Services/LanguageSelectorService.cs
+++ b/src/Baballonia/Services/LanguageSelectorService.cs
@@ -27,9 +27,10 @@ public class LanguageSelectorService(ILocalSettingsService localSettingsService)
 
     public void SetRequestedLanguage()
     {
-        Assets.Resources.Culture = new CultureInfo(Language == DefaultLanguage ?
-            CultureInfo.CurrentCulture.TwoLetterISOLanguageName :
-            Language);
+        // Use full culture name (eg. "zh-CN") so ResourceManager finds the specific satellite
+        // assembly. Fall back to the current UI culture name when DefaultLanguage is requested.
+        var cultureName = Language == DefaultLanguage ? CultureInfo.CurrentUICulture.Name : Language;
+        Assets.Resources.Culture = new CultureInfo(cultureName);
     }
 
     private string LoadLanguageFromSettings()


### PR DESCRIPTION
* Use full culture name (eg. "zh-CN") so ResourceManager finds the specific satellite assembly. Fall back to the current UI culture name when DefaultLanguage is requested.

```
public void SetRequestedLanguage()
{
    // Use full culture name (eg. "zh-CN") so ResourceManager finds the specific satellite
    // assembly. Fall back to the current UI culture name when DefaultLanguage is requested.
    var cultureName = Language == DefaultLanguage ? CultureInfo.CurrentUICulture.Name : Language;
    Assets.Resources.Culture = new CultureInfo(cultureName);
}

```
