### PR TITLE
Make Windows installer 64-bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,11 @@ jobs:
           submodules: 'recursive'
           lfs: true
 
+      - name: Install NSIS
+        uses: negrutiu/nsis-install@v2
+        with:
+           arch: x64
+
       - name: Download dependencies
         shell: pwsh
         run: ./download_dependencies.ps1
@@ -94,7 +99,7 @@ jobs:
       - name: Run makensis
         run: |
           cd src/Baballonia.Desktop
-          "C:\Program Files (x86)\NSIS\makensis.exe" main.nsi
+          makensis main.nsi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/src/Baballonia.Desktop/main.nsi
+++ b/src/Baballonia.Desktop/main.nsi
@@ -23,6 +23,7 @@
   InstallDir "$LOCALAPPDATA\${NAME}"
   InstallDirRegKey HKCU "Software\${NAME}" ""
   RequestExecutionLevel user
+  Target "amd64-unicode"  ; 64-bit
 
 ;--------------------------------
 ;Compression


### PR DESCRIPTION
This makes it so that the NSIS installer/setup that's created/made/generated/built for Windows is 64-bit instead of being 32-bit.

GitHub action run showing that this works here: https://github.com/goodusername123/Baballonia/actions/runs/21469778954