### PR TITLE
GitHub Actions provided Windows installer version string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Run makensis
         run: |
           cd src/Baballonia.Desktop
-          makensis main.nsi
+          makensis -DWORKFLOW_VERSION="${{ github.event.inputs.version-number }}" main.nsi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/src/Baballonia.Desktop/main.nsi
+++ b/src/Baballonia.Desktop/main.nsi
@@ -12,6 +12,10 @@
   !define APPFILE "Baballonia.Desktop.exe"
   !define PUBLISHER "dfgHiatus - Paradigm Reality Enhancement Laboratories"
   !define VERSION "1.1.0.9"
+  !ifdef WORKFLOW_VERSION ; override version string with one provided through GitHub Actions.
+    !undef VERSION
+    !define VERSION "${WORKFLOW_VERSION}"
+  !endif
   !define SLUG "${NAME} v${VERSION}"
 
 ;--------------------------------


### PR DESCRIPTION
Makes the version string in the Windows installer allow taking in the version string provided through GitHub Actions workflow system, otherwise fallback to the manual version defined in the `nsi` file/script.
Probably a good idea to still keep the manual version string/define up to date when possible since it will still be used when compiling outside of GitHub Actions.

Also uh idk what happened to the `main` branch on this repo but I'm just going to assume the current `v1109-rc1` branch is valid to submit this pull request to.