### PR TITLE
[POC] Restart mjpeg connection if disconnected

### DIFF
--- a/src/Baballonia.IPCameraCapture/IPCameraCapture.cs
+++ b/src/Baballonia.IPCameraCapture/IPCameraCapture.cs
@@ -6,11 +6,6 @@ using Capture = Baballonia.SDK.Capture;
 
 namespace Baballonia.IPCameraCapture;
 
-/// <summary>
-/// Captures and decodes a known-size MJPEG stream, commonly used by IP Cameras
-/// https://github.com/Larry57/SimpleMJPEGStreamViewer
-/// https://stackoverflow.com/questions/3801275/how-to-convert-image-to-byte-array
-/// </summary>
 public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger) : Capture(url, logger)
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -20,54 +15,102 @@ public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger)
     private const byte PicStart = 0xD8;
     private const byte PicEnd = 0xD9;
 
+    // Timeout duration
+    private readonly TimeSpan _readTimeout = TimeSpan.FromMilliseconds(500);
+
     public override Task<bool> StartCapture()
     {
-        Task.Run(() => StartStreaming(Source, null, null, _cancellationTokenSource.Token)); // Size of Babble frame
+        Task.Run(() => StartStreaming(Source, null, null, _cancellationTokenSource.Token));
         IsReady = true;
         return Task.FromResult(true);
     }
 
-    /// <summary>
-    /// Start a MJPEG on a http stream
-    /// </summary>
-    /// <param name="url">url of the http stream (only basic auth is implemented)</param>
-    /// <param name="login">optional login</param>
-    /// <param name="password">optional password (only basic auth is implemented)</param>
-    /// <param name="token">cancellation token used to cancel the stream parsing</param>
-    /// <param name="chunkMaxSize">Max chunk byte size when reading stream</param>
-    /// <param name="frameBufferSize">Maximum frame byte size</param>
-    /// <returns></returns>
-    ///
     private async Task StartStreaming(string url, string? login = null, string? password = null, CancellationToken? token = null,
         int chunkMaxSize = 1024, int frameBufferSize = 1024 * 1024)
     {
-        var tok = token ?? CancellationToken.None;
+        var masterToken = token ?? CancellationToken.None;
 
-        using var cli = new HttpClient();
-
-        if (!string.IsNullOrEmpty(login) && !string.IsNullOrEmpty(password))
-            cli.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
-                Convert.ToBase64String(Encoding.ASCII.GetBytes($"{login}:{password}")));
-
-        using var stream = await cli.GetStreamAsync(url).ConfigureAwait(false);
-
-        var streamBuffer = new byte[chunkMaxSize];      // Stream chunk read
-        var frameBuffer = new byte[frameBufferSize];    // Frame buffer
-
-        var frameIdx = 0;       // Last written byte location in the frame buffer
-        var inPicture = false;  // Are we currently parsing a picture ?
-        byte current = 0x00;    // The last byte read
-        byte previous = 0x00;   // The byte before
-
-        // Continuously pump the stream. The cancellation token is used to get out of there
-        while (true)
+        // OUTER LOOP: Keeps trying to connect/reconnect until the user stops capture
+        while (!masterToken.IsCancellationRequested)
         {
-            var streamLength = await stream.ReadAsync(streamBuffer, 0, chunkMaxSize, tok).ConfigureAwait(false);
-            ParseStreamBuffer(frameBuffer, ref frameIdx, streamLength, streamBuffer, ref inPicture, ref previous, ref current);
-        };
+            try
+            {
+                using var cli = new HttpClient();
+                // Optimization: Set a conservative timeout on the client itself just in case headers hang
+                cli.Timeout = TimeSpan.FromSeconds(1);
+
+                if (!string.IsNullOrEmpty(login) && !string.IsNullOrEmpty(password))
+                    cli.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
+                        Convert.ToBase64String(Encoding.ASCII.GetBytes($"{login}:{password}")));
+
+                // Pass the master token here so we can cancel during the connection phase
+                using var stream = await cli.GetStreamAsync(url, masterToken).ConfigureAwait(false);
+
+                var streamBuffer = new byte[chunkMaxSize];
+                var frameBuffer = new byte[frameBufferSize];
+
+                var frameIdx = 0;
+                var inPicture = false;
+                byte current = 0x00;
+                byte previous = 0x00;
+
+                logger.LogInformation($"Connected to stream: {url}");
+
+                // INNER LOOP: Pumps data
+                while (!masterToken.IsCancellationRequested)
+                {
+                    // Create a timeout token specifically for this read operation
+                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(masterToken);
+                    timeoutCts.CancelAfter(_readTimeout);
+
+                    int streamLength;
+                    try
+                    {
+                        // We await with the TIMEOUT token, not the master token
+                        streamLength = await stream.ReadAsync(streamBuffer, 0, chunkMaxSize, timeoutCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Check if the master token was cancelled (User requested stop)
+                        if (masterToken.IsCancellationRequested)
+                        {
+                            return; // Exit gracefully
+                        }
+
+                        // Otherwise, it was our timeoutCts that fired
+                        logger.LogWarning($"Stream read timed out ({_readTimeout.TotalMilliseconds}ms). Restarting capture...");
+                        break; // Break the INNER loop to trigger the OUTER loop (reconnect)
+                    }
+
+                    // 0 bytes usually means the server closed the connection gracefully
+                    if (streamLength == 0)
+                    {
+                        logger.LogWarning("Stream closed by server (0 bytes). Restarting...");
+                        break;
+                    }
+
+                    ParseStreamBuffer(frameBuffer, ref frameIdx, streamLength, streamBuffer, ref inPicture, ref previous, ref current);
+                }
+            }
+            catch (Exception ex) when (!masterToken.IsCancellationRequested)
+            {
+                // Catch network errors (ConnectionRefused, etc) preventing a crash
+                logger.LogError(ex, "Error in stream capture. Retrying in 1 second...");
+
+                // Wait a moment before reconnecting to avoid spamming a dead server
+                try
+                {
+                    await Task.Delay(1000, masterToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
     }
 
-    // Parse the stream buffer
+    // ... Rest of the parsing logic (ParseStreamBuffer, SearchPicture, ParsePicture, etc.) remains exactly the same ...
 
     private void ParseStreamBuffer(byte[] frameBuffer, ref int frameIdx, int streamLength, byte[] streamBuffer,
         ref bool inPicture, ref byte previous, ref byte current)
@@ -88,7 +131,6 @@ public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger)
         }
     }
 
-    // While we are looking for a picture, look for a FFD8 (end of JPEG) sequence.
     private void SearchPicture(byte[] frameBuffer, ref int frameIdx, ref int streamLength, byte[] streamBuffer,
         ref int idx, ref bool inPicture, ref byte previous, ref byte current)
     {
@@ -97,7 +139,6 @@ public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger)
             previous = current;
             current = streamBuffer[idx++];
 
-            // JPEG picture start ?
             if (previous == PicMarker && current == PicStart)
             {
                 frameIdx = 2;
@@ -109,7 +150,6 @@ public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger)
         } while (idx < streamLength);
     }
 
-    // While we are parsing a picture, fill the frame buffer until a FFD9 is reach.
     private void ParsePicture(byte[] frameBuffer, ref int frameIdx, ref int streamLength, byte[] streamBuffer,
         ref int idx, ref bool inPicture, ref byte previous, ref byte current)
     {
@@ -119,10 +159,8 @@ public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger)
             current = streamBuffer[idx++];
             frameBuffer[frameIdx++] = current;
 
-            // JPEG picture end ?
             if (previous == PicMarker && current == PicEnd)
             {
-                // Using a memory stream this way prevent arrays copy and allocations
                 using (var s = new MemoryStream(frameBuffer, 0, frameIdx))
                 {
                     try
@@ -152,9 +190,8 @@ public sealed class IpCameraCapture(string url, ILogger<IpCameraCapture> logger)
     private static byte[] TrimEnd(byte[] array)
     {
         int lastIndex = Array.FindLastIndex(array, b => b != 0);
-
         Array.Resize(ref array, lastIndex + 1);
-
         return array;
     }
 }
+

--- a/src/Baballonia.Tests/FirmwareTests/FirmwareIntegrationTest.cs
+++ b/src/Baballonia.Tests/FirmwareTests/FirmwareIntegrationTest.cs
@@ -4,90 +4,89 @@ using Baballonia.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Baballonia.Tests.FirmwareTests
+namespace Baballonia.Tests.FirmwareTests;
+
+// Here we'll put integration testing with a real microcontroller
+[TestClass]
+public class FirmwareIntegrationTest
 {
-    // Here we'll put integration testing with a real microcontroller
-    [TestClass]
-    public class FirmwareIntegrationTest
+    private static readonly string PORT = "COM4";
+    private static readonly string WIFI_SSID = "ASUS_50";
+    private static readonly string WIFI_PWD = "172839456";
+
+    private ILogger _logger;
+
+    [TestInitialize]
+    public void Initialize()
     {
-        private static readonly string PORT = "COM4";
-        private static readonly string WIFI_SSID = "ASUS_50";
-        private static readonly string WIFI_PWD = "172839456";
-
-        private ILogger _logger;
-
-        [TestInitialize]
-        public void Initialize()
+        var loggerFactory = LoggerFactory.Create(builder =>
         {
-            var loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder
-                    .AddConsole()
-                    .SetMinimumLevel(LogLevel.Debug);
-            });
+            builder
+                .AddConsole()
+                .SetMinimumLevel(LogLevel.Debug);
+        });
 
-            _logger = loggerFactory.CreateLogger("TEST");
-        }
+        _logger = loggerFactory.CreateLogger("TEST");
+    }
 
-        [TestMethod]
-        public void TestBoard()
-        {
-            var session = new FirmwareSessionV1(new SerialCommandSender(PORT), _logger);
-            Assert.IsNotNull(session.WaitForHeartbeat(TimeSpan.FromSeconds(10)));
-        }
+    [TestMethod]
+    public void TestBoard()
+    {
+        var session = new FirmwareSessionV1(new SerialCommandSender(PORT), _logger);
+        Assert.IsNotNull(session.WaitForHeartbeat(TimeSpan.FromSeconds(10)));
+    }
 
-        [TestMethod]
-        public void FindAndConnectWifiSuccess()
-        {
-            var session = new FirmwareSessionV1(new SerialCommandSender(PORT), _logger);
+    [TestMethod]
+    public void FindAndConnectWifiSuccess()
+    {
+        var session = new FirmwareSessionV1(new SerialCommandSender(PORT), _logger);
 
-            session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
-            session.SendCommand(new FirmwareRequests.SetPausedRequest(true), TimeSpan.FromSeconds(30));
-            var networks = session.SendCommand(new FirmwareRequests.ScanWifiRequest(), TimeSpan.FromSeconds(30));
-            Assert.IsTrue(networks.IsSuccess);
+        session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
+        session.SendCommand(new FirmwareRequests.SetPausedRequest(true), TimeSpan.FromSeconds(30));
+        var networks = session.SendCommand(new FirmwareRequests.ScanWifiRequest(), TimeSpan.FromSeconds(30));
+        Assert.IsTrue(networks.IsSuccess);
 
-            var find = networks.Value!.Networks.Find(network => network.Ssid == WIFI_SSID);
-            Assert.IsNotNull(find);
+        var find = networks.Value!.Networks.Find(network => network.Ssid == WIFI_SSID);
+        Assert.IsNotNull(find);
 
-            session.SendCommand(new FirmwareRequests.SetWifiRequest(WIFI_SSID, WIFI_PWD), TimeSpan.FromSeconds(30));
+        session.SendCommand(new FirmwareRequests.SetWifiRequest(WIFI_SSID, WIFI_PWD), TimeSpan.FromSeconds(30));
 
-            var connectionres = session.SendCommand(new FirmwareRequests.ConnectWifiRequest(), TimeSpan.FromSeconds(30));
-            Assert.IsNotNull(connectionres);
+        var connectionres = session.SendCommand(new FirmwareRequests.ConnectWifiRequest(), TimeSpan.FromSeconds(30));
+        Assert.IsNotNull(connectionres);
 
-            var wifistatus = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest(), TimeSpan.FromSeconds(30));
-            Assert.IsTrue(wifistatus.IsSuccess);
-            Assert.AreEqual("connected", wifistatus.Value!.Status);
+        var wifistatus = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest(), TimeSpan.FromSeconds(30));
+        Assert.IsTrue(wifistatus.IsSuccess);
+        Assert.AreEqual("connected", wifistatus.Value!.Status);
 
-            session.SendCommand(new FirmwareRequests.SetPausedRequest(false), TimeSpan.FromSeconds(30));
+        session.SendCommand(new FirmwareRequests.SetPausedRequest(false), TimeSpan.FromSeconds(30));
 
-            session.Dispose();
-        }
+        session.Dispose();
+    }
 
-        [TestMethod]
-        public void FindAndConnectWifiFail()
-        {
-            var session = new FirmwareSessionV1(new SerialCommandSender(PORT), _logger);
+    [TestMethod]
+    public void FindAndConnectWifiFail()
+    {
+        var session = new FirmwareSessionV1(new SerialCommandSender(PORT), _logger);
 
-            session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
-            session.SendCommand(new FirmwareRequests.SetPausedRequest(true), TimeSpan.FromSeconds(30));
-            var networks = session.SendCommand(new FirmwareRequests.ScanWifiRequest(), TimeSpan.FromSeconds(30));
-            Assert.IsTrue(networks.IsSuccess);
+        session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
+        session.SendCommand(new FirmwareRequests.SetPausedRequest(true), TimeSpan.FromSeconds(30));
+        var networks = session.SendCommand(new FirmwareRequests.ScanWifiRequest(), TimeSpan.FromSeconds(30));
+        Assert.IsTrue(networks.IsSuccess);
 
-            var find = networks.Value!.Networks.Find(network => network.Ssid == WIFI_SSID);
-            Assert.IsNotNull(find);
+        var find = networks.Value!.Networks.Find(network => network.Ssid == WIFI_SSID);
+        Assert.IsNotNull(find);
 
-            session.SendCommand(new FirmwareRequests.SetWifiRequest("", WIFI_PWD), TimeSpan.FromSeconds(30));
+        session.SendCommand(new FirmwareRequests.SetWifiRequest("", WIFI_PWD), TimeSpan.FromSeconds(30));
 
-            var connectionres = session.SendCommand(new FirmwareRequests.ConnectWifiRequest(), TimeSpan.FromSeconds(30));
-            Assert.IsNotNull(connectionres);
+        var connectionres = session.SendCommand(new FirmwareRequests.ConnectWifiRequest(), TimeSpan.FromSeconds(30));
+        Assert.IsNotNull(connectionres);
 
-            var wifistatus = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest(), TimeSpan.FromSeconds(30));
-            Assert.IsTrue(wifistatus.IsSuccess);
-            Assert.AreEqual("error", wifistatus.Value!.Status);
+        var wifistatus = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest(), TimeSpan.FromSeconds(30));
+        Assert.IsTrue(wifistatus.IsSuccess);
+        Assert.AreEqual("error", wifistatus.Value!.Status);
 
-            session.SendCommand(new FirmwareRequests.SetPausedRequest(false), TimeSpan.FromSeconds(30));
+        session.SendCommand(new FirmwareRequests.SetPausedRequest(false), TimeSpan.FromSeconds(30));
 
-            session.Dispose();
-        }
+        session.Dispose();
     }
 }

--- a/src/Baballonia.Tests/FirmwareTests/FirmwareServiceTest.cs
+++ b/src/Baballonia.Tests/FirmwareTests/FirmwareServiceTest.cs
@@ -7,132 +7,124 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Baballonia.Tests.FirmwareTests
+namespace Baballonia.Tests.FirmwareTests;
+
+class MockCommandSender(List<string> lines) : ICommandSender
 {
-    class MockCommandSender : ICommandSender
+    public void Dispose()
     {
-        private List<string> lines;
-
-        public MockCommandSender(List<string> lines)
-        {
-            this.lines = lines;
-        }
-
-        public void Dispose()
-        {
-
-        }
-
-        public string ReadLine(TimeSpan timeout)
-        {
-            string line = lines[0];
-            lines.RemoveAt(0);
-
-            return line;
-        }
-
-        public void WriteLine(string message)
-        {
-        }
-    }
-    [TestClass]
-    public class FirmwareServiceTest
-    {
-        private ILoggerFactory _loggerFactory;
-        private ILogger _logger;
-
-        [TestInitialize]
-        public void Initialize()
-        {
-            _loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder
-                    .AddConsole()
-                    .SetMinimumLevel(LogLevel.Trace);
-            });
-
-            _logger = _loggerFactory.CreateLogger("TEST");
-        }
-
-
-        private FirmwareService CreateService(List<string> mockResponses)
-        {
-            var loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder
-                    .AddConsole()
-                    .SetMinimumLevel(LogLevel.Trace);
-            });
-
-            var serviceLogger = loggerFactory.CreateLogger<FirmwareService>();
-            var logger = loggerFactory.CreateLogger<FirmwareServiceTest>();
-
-            var mockCommandSenderFactory = new Mock<ICommandSenderFactory>();
-            mockCommandSenderFactory
-                .Setup(s => s.Create(CommandSenderType.Serial, "COM4"))
-                .Returns(new MockCommandSender(mockResponses));
-
-            return new FirmwareService(serviceLogger, mockCommandSenderFactory.Object);
-        }
-        [TestMethod]
-        public void TestSendCommand()
-        {
-            List<string> mockLines = new List<string>();
-            mockLines.Add("""{"heartbeat":{}}""");
-            mockLines.Add("""{"results":        ["{\"result\":\"{\\\"status\\\":\\\"connected\\\",\\\"networks_configured\\\":1,\\\"ip_address\\\":\\\"192.168.0.246\\\"}\"}"]} """);
-
-            var firmwareService = CreateService(mockLines);
-
-            var session = firmwareService.StartSession(CommandSenderType.Serial, "COM4");
-            session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
-
-            var results = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest(), TimeSpan.FromSeconds(10));
-            Assert.AreEqual("192.168.0.246", results.Value!.IpAddress);
-        }
-
-
-        [TestMethod]
-        public void TestSendBatchCommand()
-        {
-            // List<string> mockLines = new List<string>();
-            // mockLines.Add("""{"heartbeat":{}}""");
-            // mockLines.Add("""
-            //         {"results":[
-            //         {"command_name":"pause", "status": "SUCCESS" },
-            //         {"command_name":"get_wifi_status", "status": "SUCCESS" }
-            //     ]}
-            //     """);
-            //
-            // var firmwareService = CreateService(mockLines);
-            // var session = firmwareService.StartSession(CommandSenderType.Serial, "COM4");
-            // session.WaitForHeartbeat();
-            //
-            // session.SendCommand(new FirmwareRequests.SetPausedRequest(true));
-            // var commandResult = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest());
-            // Assert.AreEqual("");
-        }
-
-        [TestMethod]
-        public void TestSendGeneric()
-        {
-            List<string> mockLines = new List<string>();
-            mockLines.Add("""{"heartbeat":{}}""");
-            mockLines.Add("""
-                              {"results":[
-                              "{\"command_name\":\"pause\", \"status\":\"SUCCESS\"}"
-                          ]}
-                          """);
-
-            var firmwareService = CreateService(mockLines);
-            var session = firmwareService.StartSession(CommandSenderType.Serial, "COM4");
-            session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
-
-            var commandResult = session.SendCommand(new FirmwareRequests.SetPausedRequest(true), TimeSpan.FromSeconds(10));
-            Assert.AreEqual("""
-                            {"command_name":"pause", "status":"SUCCESS"}
-                            """, commandResult.Value!.ToString());
-        }
-
 
     }
+
+    public string ReadLine(TimeSpan timeout)
+    {
+        var line = lines[0];
+        lines.RemoveAt(0);
+
+        return line;
+    }
+
+    public void WriteLine(string message)
+    {
+    }
+}
+[TestClass]
+public class FirmwareServiceTest
+{
+    private ILoggerFactory _loggerFactory;
+    private ILogger _logger;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder
+                .AddConsole()
+                .SetMinimumLevel(LogLevel.Trace);
+        });
+
+        _logger = _loggerFactory.CreateLogger("TEST");
+    }
+
+
+    private FirmwareService CreateService(List<string> mockResponses)
+    {
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder
+                .AddConsole()
+                .SetMinimumLevel(LogLevel.Trace);
+        });
+
+        var serviceLogger = loggerFactory.CreateLogger<FirmwareService>();
+        var logger = loggerFactory.CreateLogger<FirmwareServiceTest>();
+
+        var mockCommandSenderFactory = new Mock<ICommandSenderFactory>();
+        mockCommandSenderFactory
+            .Setup(s => s.Create(CommandSenderType.Serial, "COM4"))
+            .Returns(new MockCommandSender(mockResponses));
+
+        return new FirmwareService(serviceLogger, mockCommandSenderFactory.Object);
+    }
+    [TestMethod]
+    public void TestSendCommand()
+    {
+        var mockLines = new List<string>();
+        mockLines.Add("""{"heartbeat":{}}""");
+        mockLines.Add("""{"results":        ["{\"result\":\"{\\\"status\\\":\\\"connected\\\",\\\"networks_configured\\\":1,\\\"ip_address\\\":\\\"192.168.0.246\\\"}\"}"]} """);
+
+        var firmwareService = CreateService(mockLines);
+
+        var session = firmwareService.StartSession(CommandSenderType.Serial, "COM4");
+        session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
+
+        var results = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest(), TimeSpan.FromSeconds(10));
+        Assert.AreEqual("192.168.0.246", results.Value!.IpAddress);
+    }
+
+
+    [TestMethod]
+    public void TestSendBatchCommand()
+    {
+        // List<string> mockLines = new List<string>();
+        // mockLines.Add("""{"heartbeat":{}}""");
+        // mockLines.Add("""
+        //         {"results":[
+        //         {"command_name":"pause", "status": "SUCCESS" },
+        //         {"command_name":"get_wifi_status", "status": "SUCCESS" }
+        //     ]}
+        //     """);
+        //
+        // var firmwareService = CreateService(mockLines);
+        // var session = firmwareService.StartSession(CommandSenderType.Serial, "COM4");
+        // session.WaitForHeartbeat();
+        //
+        // session.SendCommand(new FirmwareRequests.SetPausedRequest(true));
+        // var commandResult = session.SendCommand(new FirmwareRequests.GetWifiStatusRequest());
+        // Assert.AreEqual("");
+    }
+
+    [TestMethod]
+    public void TestSendGeneric()
+    {
+        var mockLines = new List<string>();
+        mockLines.Add("""{"heartbeat":{}}""");
+        mockLines.Add("""
+                          {"results":[
+                          "{\"command_name\":\"pause\", \"status\":\"SUCCESS\"}"
+                      ]}
+                      """);
+
+        var firmwareService = CreateService(mockLines);
+        var session = firmwareService.StartSession(CommandSenderType.Serial, "COM4");
+        session.WaitForHeartbeat(TimeSpan.FromSeconds(10));
+
+        var commandResult = session.SendCommand(new FirmwareRequests.SetPausedRequest(true), TimeSpan.FromSeconds(10));
+        Assert.AreEqual("""
+                        {"command_name":"pause", "status":"SUCCESS"}
+                        """, commandResult.Value!.ToString());
+    }
+
+
 }

--- a/src/Baballonia/Models/FirmwareSession.cs
+++ b/src/Baballonia/Models/FirmwareSession.cs
@@ -13,30 +13,22 @@ namespace Baballonia.Models;
 /// <summary>
 /// Thread safe, async supported Session object for sending and receiving commands in json format
 /// </summary>
-public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
+public class FirmwareSessionV1(ICommandSender commandSender, ILogger logger) : IVersionedFirmwareSession, IDisposable
 {
-    private ICommandSender _commandSender;
-    private ILogger _logger;
     // this is legacy by default so it will always stay as 0.0.0
-    public Version Version { get; set; } = new Version(0, 0, 0);
+    public Version Version { get; set; } = new(0, 0, 0);
 
-    JsonExtractor jsonExtractor = new JsonExtractor();
+    private readonly JsonExtractor _jsonExtractor = new();
 
-    private SemaphoreSlim _lock = new(1, 1);
+    private readonly SemaphoreSlim _lock = new(1, 1);
 
-    JsonSerializerOptions _options = new()
+    private static readonly JsonSerializerOptions Options = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         WriteIndented = false
     };
 
-    public FirmwareSessionV1(ICommandSender commandSender, ILogger logger)
-    {
-        _commandSender = commandSender;
-        _logger = logger;
-    }
-
-    private bool JsonHasPrefix(JsonDocument json, string key)
+    private static bool JsonHasPrefix(JsonDocument json, string key)
     {
         if (json.RootElement.ValueKind != JsonValueKind.Object) return false;
 
@@ -52,8 +44,8 @@ public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
     private void SendCommand(string command)
     {
         var payload = command;
-        _logger.LogDebug("Sending payload: {}", payload);
-        _commandSender.WriteLine(payload);
+        logger.LogDebug("Sending payload: {}", payload);
+        commandSender.WriteLine(payload);
     }
 
     private JsonDocument? ReadResponse(string responseJsonRootKey, TimeSpan timeout)
@@ -62,16 +54,15 @@ public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
         {
             Thread.Sleep(10); // give it some breathing time
 
-            JsonDocument json = jsonExtractor.ReadUntilValidJson(() => _commandSender.ReadLine(timeout), timeout);
-            _logger.LogDebug("Received json: {}", json.RootElement.GetRawText());
+            var json = _jsonExtractor.ReadUntilValidJson(() => commandSender.ReadLine(timeout), timeout);
+            logger.LogDebug("Received json: {}", json.RootElement.GetRawText());
             if (JsonHasPrefix(json, responseJsonRootKey))
                 return json;
-            if (JsonHasPrefix(json, "error"))
-            {
-                var err = JsonSerializer.Deserialize<FirmwareResponses.Error>(json);
-                _logger.LogError(err.error);
-                return null;
-            }
+            if (!JsonHasPrefix(json, "error")) continue;
+
+            var err = json.Deserialize<FirmwareResponses.Error>();
+            logger.LogError(err.error);
+            return null;
         }
     }
 
@@ -95,9 +86,9 @@ public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
                 return res?.Deserialize<FirmwareResponses.Heartbeat>();
             }
         }
-        catch (TimeoutException ex)
+        catch (TimeoutException)
         {
-            _logger.LogError("Timeout reached");
+            logger.LogError("Timeout reached");
             return null;
         }
         finally
@@ -114,7 +105,7 @@ public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
         try
         {
             var genericReqList = new { commands = new[] { request } };
-            var serialized = JsonSerializer.Serialize(genericReqList, _options);
+            var serialized = JsonSerializer.Serialize(genericReqList, Options);
             SendCommand(serialized);
             var jsonDoc = ReadResponse("results", timeout);
             var response = jsonDoc?.Deserialize<FirmwareResponses.GenericResponse>();
@@ -154,7 +145,7 @@ public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
         {
             var genericReqList = new { commands = new[] { request } };
 
-            var serialized = JsonSerializer.Serialize(genericReqList, _options);
+            var serialized = JsonSerializer.Serialize(genericReqList, Options);
             SendCommand(serialized);
 
             // special case because a list of networks comes in a separate json
@@ -219,7 +210,7 @@ public class FirmwareSessionV1 : IVersionedFirmwareSession, IDisposable
 
     public void Dispose()
     {
-        if (_commandSender != null)
-            _commandSender.Dispose();
+        if (commandSender != null)
+            commandSender.Dispose();
     }
 }

--- a/src/Baballonia/Models/FirmwareSessionV2.cs
+++ b/src/Baballonia/Models/FirmwareSessionV2.cs
@@ -10,47 +10,35 @@ using Microsoft.Extensions.Logging;
 
 namespace Baballonia.Models;
 
-public class FirmwareSessionV2 : IVersionedFirmwareSession, IDisposable
+public class FirmwareSessionV2(ICommandSender commandSender, ILogger logger) : IVersionedFirmwareSession, IDisposable
 {
-    private ICommandSender _commandSender;
-    private ILogger _logger;
-
     // default to minimal required version for which this Session is expected to work
     // will be overridden by factory if needed
-    public Version Version { get; set; } = new Version(0, 0, 1);
+    public Version Version { get; set; } = new(0, 0, 1);
 
-    JsonExtractor jsonExtractor = new JsonExtractor();
+    private readonly JsonExtractor _jsonExtractor = new();
 
-    private SemaphoreSlim _lock = new(1, 1);
+    private readonly SemaphoreSlim _lock = new(1, 1);
 
-    JsonSerializerOptions _options = new()
+    private static readonly JsonSerializerOptions Options = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         WriteIndented = false
     };
 
-    public FirmwareSessionV2(ICommandSender commandSender, ILogger logger)
-    {
-        _commandSender = commandSender;
-        _logger = logger;
-    }
-
     private FirmwareResponses.GenericResponseV2? ReadResponse(TimeSpan timeout)
     {
-        JsonDocument json = jsonExtractor.ReadUntilValidJson(() => _commandSender.ReadLine(timeout), timeout);
-        _logger.LogDebug("Received json: {}", json.RootElement.GetRawText());
+        var json = _jsonExtractor.ReadUntilValidJson(() => commandSender.ReadLine(timeout), timeout);
+        logger.LogDebug("Received json: {}", json.RootElement.GetRawText());
         var response = json.Deserialize<FirmwareResponses.GenericResponseV2>();
-        if (response == null)
-            return null;
-
-        return response;
+        return response ?? null;
     }
 
     private void SendCommand(string command)
     {
         var payload = command + "\n";
-        _logger.LogDebug("Sending payload: {}", payload);
-        _commandSender.WriteLine(payload);
+        logger.LogDebug("Sending payload: {}", payload);
+        commandSender.WriteLine(payload);
     }
 
 
@@ -63,7 +51,7 @@ public class FirmwareSessionV2 : IVersionedFirmwareSession, IDisposable
         {
             var genericReqList = new { commands = new[] { request } };
 
-            var serialized = JsonSerializer.Serialize(genericReqList, _options);
+            var serialized = JsonSerializer.Serialize(genericReqList, Options);
             SendCommand(serialized);
 
             var response = ReadResponse(timeout);
@@ -100,7 +88,7 @@ public class FirmwareSessionV2 : IVersionedFirmwareSession, IDisposable
         {
             var genericReqList = new { commands = new[] { request } };
 
-            var serialized = JsonSerializer.Serialize(genericReqList, _options);
+            var serialized = JsonSerializer.Serialize(genericReqList, Options);
             SendCommand(serialized);
 
             var response = ReadResponse(timeout);
@@ -154,7 +142,7 @@ public class FirmwareSessionV2 : IVersionedFirmwareSession, IDisposable
 
     public void Dispose()
     {
-        if (_commandSender != null)
-            _commandSender.Dispose();
+        if (commandSender != null)
+            commandSender.Dispose();
     }
 }


### PR DESCRIPTION
# Warn: LLM was used

## Description
Restarts the connection if no data for 500ms (I think)

### Motivation
I wanted to try Baballonia, but my mjpeg connection was too unstable

### Further warning
I have not read the code and I am currently slightly drunk. 
I threw `IPCameraCapture.cs` into Google Gemini ([Chat link](https://gemini.google.com/share/6ef3ca76ce1f))
**This pull request should not be merged!** Since the LLM code has not been verified.

## Working video (Only tested on Windows)
https://github.com/user-attachments/assets/b67bc375-5138-4eb2-82a8-7d5efe0108cc

## Contributting notes
Currently, ``git clone`` of the repo and following the build instructions is outdated.
I had to do:
###### Placing these command here if I come back to do a proper pull request.
```
dotnet add src/Baballonia/Baballonia.csproj package Tmds.DBus
dotnet add src/Baballonia/Baballonia.csproj package HarfBuzzSharp
dotnet add src/Baballonia/Baballonia.csproj package HyperText.Avalonia# Add the missing namespaces
dotnet add src/Baballonia/Baballonia.csproj package Tmds.DBus
dotnet add src/Baballonia/Baballonia.csproj package HarfBuzzSharp
dotnet add src/Baballonia/Baballonia.csproj package HyperText.Avalonia
```
This problem affects NixOS and Windows. (rest is untested)

But from the peek into the codebase, the code is surprisingly well orginized. That's pretty cool