### PR TITLE
Make Linux UVC offer workarounds, details

### DIFF
--- a/src/Baballonia.Desktop/DesktopDeviceEnumerator.cs
+++ b/src/Baballonia.Desktop/DesktopDeviceEnumerator.cs
@@ -216,9 +216,18 @@ public sealed class DesktopDeviceEnumerator(ILogger<DesktopDeviceEnumerator> log
                 udev_unref(udev);
             }
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            cameraDict.Add($"Error listing UVC devices: {e.Message}", "error");
+            Logger.LogWarning($"Unable to probe UVC devices: {ex.Message}");
+
+            const string workarounds = """
+        Workarounds:
+        - Try the Steam scout 1.0 runtime (not sniper 3.0), installing libudev, building from source, or joining the plugdev group.
+        - We only support Steam and tarball releases, not the AUR package.
+        - Babble Boards do not support UVC/Serial on Linux, use a wireless configuration.
+        """;
+            Logger.LogWarning(workarounds);
+            cameraDict.Add($"Unable to probe UVC devices. {workarounds}", "error");
         }
     }
 


### PR DESCRIPTION
Instead of throwing a giant exception block, suggest a couple of workarounds in the device dropdown when we cannot probe UVC cameras:

>  Workarounds:
        - Try the Steam scout 1.0 runtime (not sniper 3.0), installing libudev, building from source, or joining the plugdev group.
        - We only support Steam and tarball releases, not the AUR package.
        - Babble Boards do not support UVC/Serial on Linux, use a wireless configuration.