### PR TITLE
WIP: Reintegrate CUDA support

### DIFF
--- a/src/Baballonia.Desktop/Baballonia.Desktop.csproj
+++ b/src/Baballonia.Desktop/Baballonia.Desktop.csproj
@@ -33,7 +33,8 @@
 
 	    <!-- Windows-specific -->
         <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.13.0.20260302" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-	    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.24.3" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+        <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.24.3" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+        <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.24.3" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
         <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.2" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
 		<PackageReference Include="DirectShowLib" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
 
@@ -48,7 +49,7 @@
 
         <PackageReference Include="Project-Babble.OpenCvSharp4.mini.runtime.ubuntu.22.04-arm64" Version="4.11.0.1" Condition="$([MSBuild]::IsOSPlatform('Linux')) And
              $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().Contains('Arm'))" />
-	    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+	    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="1.22.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
         <PackageReference Include="Xaml.Behaviors.Interactions.Draggable" Version="11.3.9.5" />
         <ProjectReference Include="..\Baballonia.LibV4L2Capture\Baballonia.LibV4L2Capture.csproj" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />

--- a/src/Baballonia/Services/DefaultInferenceRunner.cs
+++ b/src/Baballonia/Services/DefaultInferenceRunner.cs
@@ -113,10 +113,24 @@ public class DefaultInferenceRunner(ILoggerFactory loggerFactory) : IInferenceRu
 
         // If the user's system does not support DirectML (for whatever reason,
         // it's shipped with Windows 10, version 1903(10.0; Build 18362)+
-        // Fallback on good ol' CUDA
+        // Fallback on CUDA (also, if you're on Linux)
+        OrtCUDAProviderOptions cudaProviderOptions = null!;
         try
         {
-            sessionOptions.AppendExecutionProvider_CUDA();
+            cudaProviderOptions = new OrtCUDAProviderOptions();
+            var providerOptionsDict = new Dictionary<string, string>
+            {
+                ["device_id"] = "0",
+                ["gpu_mem_limit"] = "2147483648",
+                // Overkill options
+                // ["arena_extend_strategy"] = "kSameAsRequested",
+                // ["cudnn_conv_algo_search"] = "DEFAULT",
+                // ["do_copy_in_default_stream"] = "1",
+                // ["cudnn_conv_use_max_workspace"] = "1",
+                // ["cudnn_conv1d_pad_to_nc1d"] = "1"
+            };
+            cudaProviderOptions.UpdateOptions(providerOptionsDict);
+            sessionOptions = SessionOptions.MakeSessionOptionWithCudaProvider(cudaProviderOptions);
             _logger.LogInformation("Initialized ExecutionProvider: CUDA for {ModelName}", modelName);
             return;
         }
@@ -124,20 +138,13 @@ public class DefaultInferenceRunner(ILoggerFactory loggerFactory) : IInferenceRu
         {
             _logger.LogWarning("Failed to create CUDA Execution Provider.");
         }
+        finally
+        {
+            cudaProviderOptions.Dispose();
+        }
 
         // And, if CUDA fails (or we have an AMD card)
-        // Try one more time with MiGraphX/ROCm
-        try
-        {
-            sessionOptions.AppendExecutionProvider_ROCm();
-            _logger.LogInformation("Initialized ExecutionProvider: ROCm for {ModelName}", modelName);
-            return;
-        }
-        catch (Exception)
-        {
-            _logger.LogWarning("Failed to create ROCm Execution Provider.");
-        }
-
+        // Try one more time with MiGraphX
         try
         {
             sessionOptions.AppendExecutionProvider_MIGraphX();


### PR DESCRIPTION
This PR has a bit of a story attached to it.

As of the latest release, inference on Windows is accelerated through the DirectML execution provider, and there is no acceleration on Linux. The AMD backends, ROCM and MiGraphX, do not have any NuGet packages available, and the [former is deprecated](https://onnxruntime.ai/docs/execution-providers/ROCm-ExecutionProvider.html). The effort to maintain our own execution providers is not worth it at this time.

On the flip side, CUDA has been a more interesting. For us to have proper CUDA support, we need to bundle a parts of the CUDNN runtime with the application, as the publicly available NuGet package does not do this by default (and hasn't for a while, by the looks of some things online). This process is literally dropping in a single missing file, as has been my experience on Windows. I can't speak for Linux, at least on WSL Ubuntu 24.04.

I learned about this after modifying how I was appending the execution provider to CUDA. Dropping `AppendExecutionProvider_CUDA` for the longer code block has made things work for me on a 5060ti and CUDA 12-13. This is the only card I have to reliably test against, I can't speak against other hardware.

There are workarounds. This could be done in the actions build step, or we could copy the file over on the local user machine. These implementations appear fragile - This hasn't even factored in instructing the user to install compatible versions of CUDA and CUDNN on their system, build size, etc.

In the spirit of transparency, I'm going to push up what I have and see what others make and or think of it. Cheers, and good luck