### PR TITLE
Add a check to ignore empty images

### DIFF
--- a/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
@@ -39,8 +39,6 @@ public class DualCameraSource : IVideoSource
         leftImage ??= LastLeftImage;
         rightImage ??= LastRightImage;
 
-        if (leftImage.Empty() || rightImage.Empty())
-            return null;
 
         switch (leftImage)
         {
@@ -59,7 +57,9 @@ public class DualCameraSource : IVideoSource
         int minHeight = Math.Min(leftImage.Rows, rightImage.Rows);
         int minWidth = Math.Min(leftImage.Cols, rightImage.Cols);
 
-
+        if (leftImage.Empty() || rightImage.Empty())
+            return null;
+            
         Mat resizedLeft = new Mat();
         Mat resizedRight = new Mat();
         Cv2.Resize(leftImage, resizedLeft, new Size(minWidth, minHeight));

--- a/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
@@ -40,15 +40,11 @@ public class DualCameraSource : IVideoSource
         rightImage ??= LastRightImage;
 
         // Check if either one of the images is null or empty
-        if (leftImage == null || rightImage == null){
-            _logger.LogWarning("Discarding empty frame from Dual Camera");
+        if (leftImage == null || rightImage == null)
             return null;
-        }
 
-        if (leftImage.Empty() || rightImage.Empty()){
-            _logger.LogWarning("Discarding empty frame from Dual Camera");
+        if (leftImage.Empty() || rightImage.Empty())
             return null;
-        }
 
         switch (leftImage)
         {

--- a/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
@@ -39,6 +39,13 @@ public class DualCameraSource : IVideoSource
         leftImage ??= LastLeftImage;
         rightImage ??= LastRightImage;
 
+        // Check if either one of the images is null or empty
+        if (leftImage == null || rightImage == null)
+            return null;
+
+        if (leftImage.Empty() || rightImage.Empty())
+            return null;
+
         switch (leftImage)
         {
             case null when rightImage == null:

--- a/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
@@ -39,10 +39,6 @@ public class DualCameraSource : IVideoSource
         leftImage ??= LastLeftImage;
         rightImage ??= LastRightImage;
 
-        // Check if either one of the images is null or empty
-        if (leftImage == null || rightImage == null)
-            return null;
-
         if (leftImage.Empty() || rightImage.Empty())
             return null;
 

--- a/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/DualCameraSource.cs
@@ -40,11 +40,15 @@ public class DualCameraSource : IVideoSource
         rightImage ??= LastRightImage;
 
         // Check if either one of the images is null or empty
-        if (leftImage == null || rightImage == null)
+        if (leftImage == null || rightImage == null){
+            _logger.LogWarning("Discarding empty frame from Dual Camera");
             return null;
+        }
 
-        if (leftImage.Empty() || rightImage.Empty())
+        if (leftImage.Empty() || rightImage.Empty()){
+            _logger.LogWarning("Discarding empty frame from Dual Camera");
             return null;
+        }
 
         switch (leftImage)
         {

--- a/src/Baballonia/Services/Inference/VideoSources/SingleCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/SingleCameraSource.cs
@@ -78,10 +78,8 @@ public class SingleCameraSource : IVideoSource
             image = convertedMat;
         }
 
-        if (image.Empty()) {
-            _logger.LogWarning("Discarding empty frame from a Single Camera");
+        if (image.Empty())
             return null;
-        }
             
         return image;
     }

--- a/src/Baballonia/Services/Inference/VideoSources/SingleCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/SingleCameraSource.cs
@@ -78,6 +78,8 @@ public class SingleCameraSource : IVideoSource
             image = convertedMat;
         }
 
+        if (image.Empty())
+            return null;
 
         return image;
     }

--- a/src/Baballonia/Services/Inference/VideoSources/SingleCameraSource.cs
+++ b/src/Baballonia/Services/Inference/VideoSources/SingleCameraSource.cs
@@ -78,9 +78,11 @@ public class SingleCameraSource : IVideoSource
             image = convertedMat;
         }
 
-        if (image.Empty())
+        if (image.Empty()) {
+            _logger.LogWarning("Discarding empty frame from a Single Camera");
             return null;
-
+        }
+            
         return image;
     }
 


### PR DESCRIPTION
Possibly fixes issue #210
Makes baballonia more error resistant (in case camera sends "valid" empty jpegs) as it reduces camera disconnects.