### PR TITLE
Integrate independent wink calibration and localized VR instructions

### DIFF
--- a/src/Baballonia.Desktop/Calibration/ICalibrationRoutine.cs
+++ b/src/Baballonia.Desktop/Calibration/ICalibrationRoutine.cs
@@ -48,7 +48,8 @@ public sealed class BaseTutorialStep(string name, TimeSpan time) : PacketHandler
 
     public override void OnRoutineFinishedPacket(RoutineFinishedPacket packet)
     {
-        Token.SetResult();
+        if (string.Equals(packet.RoutineName, Name, StringComparison.OrdinalIgnoreCase))
+            Token.TrySetResult();
     }
 }
 
@@ -98,7 +99,8 @@ public abstract class PositionalAwareCaptureStep(string name, uint flags, TimeSp
 
     public override void OnRoutineFinishedPacket(RoutineFinishedPacket packet)
     {
-        Token.SetResult();
+        if (string.Equals(packet.RoutineName, Name, StringComparison.OrdinalIgnoreCase))
+            Token.TrySetResult();
     }
 
     public void Dispose()
@@ -150,7 +152,8 @@ public abstract class BaseCaptureStep(string name, uint flags, TimeSpan time) : 
 
     public override void OnRoutineFinishedPacket(RoutineFinishedPacket packet)
     {
-        Token.SetResult();
+        if (string.Equals(packet.RoutineName, Name, StringComparison.OrdinalIgnoreCase))
+            Token.TrySetResult();
     }
 
     public void Dispose()
@@ -298,7 +301,9 @@ public class BaseEyeCaptureStep(
     float browAngry = 0,
     float widen = 0,
     float squint = 0,
-    float dilate = 0)
+    float dilate = 0,
+    float? leftLid = null,
+    float? rightLid = null)
     : BaseCaptureStep(name, flags, time)
 {
     public override async Task ExecuteAsync(OverlayMessageDispatcher dispatcher, CancellationToken ct)
@@ -325,8 +330,8 @@ public class BaseEyeCaptureStep(
         var frame = base.AddFrame(images);
         frame.Header = frame.Header with
         {
-            RoutineLeftLid = lid,
-            RoutineRightLid = lid,
+            RoutineLeftLid = leftLid ?? lid,
+            RoutineRightLid = rightLid ?? lid,
             RoutineBrowRaise = browRaise,
             RoutineBrowAngry = browAngry,
             RoutineWiden = widen,
@@ -357,6 +362,9 @@ public class TrainerCalibrationStep(ITrainerService overlayTrainer) : ICalibrati
         dispatcher.Dispatch(new RunVariableLenghtRoutinePacket(Name, TimeSpan.FromSeconds(120)));
         var onProgressHandler = (TrainerProgressReportPacket packet) => { dispatcher.Dispatch(packet); };
         overlayTrainer.OnProgress += onProgressHandler;
+        // The trainer first scans and indexes the capture file, which can take a while before its
+        // first batch line. Show immediately that training has started instead of an idle graph.
+        dispatcher.Dispatch(new TrainerProgressReportPacket("Batch", 0, 1, 0));
         overlayTrainer.RunTraining(Path.Combine(Utils.ModelDataDirectory, "user_cal.bin"),
             Path.Combine(Utils.ModelDataDirectory, "tuned_temporal_eye_tracking_latest.onnx"));
         await overlayTrainer.WaitAsync();
@@ -375,6 +383,10 @@ public class EyeCaptureStepFactory(IEyePipelineEventBus eyePipelineEvent)
         float squint = 0,
         float dilate = 0) =>
         new(eyePipelineEvent, name, flags, time, lid, browRaise, browAngry, widen, squint, dilate);
+
+    public BaseEyeCaptureStep CreateAsymmetricLids(string name, uint flags, TimeSpan time,
+        float leftLid, float rightLid) =>
+        new(eyePipelineEvent, name, flags, time, leftLid: leftLid, rightLid: rightLid);
 
     /// <summary>
     /// Like <see cref="Create"/>, but the step also records per-frame gaze ground-truth from the
@@ -432,6 +444,20 @@ public class EyeCalibration(
                 CaptureFlags.FLAG_VERSION_BIT1,
                 TimeSpan.FromSeconds(10), lid: 0
             ),
+            new BaseTutorialStep("winklefttutorial", TimeSpan.FromSeconds(10)),
+            eyeCaptureStepFactory.CreateAsymmetricLids("winkleft",
+                CaptureFlags.FLAG_GOOD_DATA |
+                CaptureFlags.FLAG_IN_MOVEMENT |
+                CaptureFlags.FLAG_VERSION_BIT1,
+                TimeSpan.FromSeconds(10), leftLid: 1, rightLid: 0
+            ),
+            new BaseTutorialStep("winkrighttutorial", TimeSpan.FromSeconds(10)),
+            eyeCaptureStepFactory.CreateAsymmetricLids("winkright",
+                CaptureFlags.FLAG_GOOD_DATA |
+                CaptureFlags.FLAG_IN_MOVEMENT |
+                CaptureFlags.FLAG_VERSION_BIT1,
+                TimeSpan.FromSeconds(10), leftLid: 0, rightLid: 1
+            ),
 
             new BaseTutorialStep("widentutorial", TimeSpan.FromSeconds(10)),
                 eyeCaptureStepFactory.CreateGazeExpression("widen",
@@ -448,7 +474,7 @@ public class EyeCalibration(
             //steps.Add(_eyeCaptureStepFactory.Create("covergence",
             //    CaptureFlags.FLAG_GOOD_DATA | CaptureFlags.FLAG_WHATEVER_NOT_IMPLEMENTED));
 
-            new MergeBinsStep("gaze.bin", "gazeexpr.bin", "blink.bin", "widen.bin", "squint.bin", "brow.bin"),
+            new MergeBinsStep("gaze.bin", "gazeexpr.bin", "blink.bin", "winkleft.bin", "winkright.bin", "widen.bin", "squint.bin", "brow.bin"),
             // new MergeBinsStep("gaze.bin", "blink.bin"),
             new TrainerCalibrationStep(trainer),
             new CommandDispatchStep("close")
@@ -462,11 +488,11 @@ public class EyeCalibration(
     {
         List<ICalibrationStep> steps =
         [
-            new BaseTutorialStep("gazetutorialshort", TimeSpan.FromSeconds(5)),
+            new BaseTutorialStep("gazetutorialshort", TimeSpan.FromSeconds(10)),
             new GazeCaptureStep(eyePipelineEventBus, TimeSpan.FromSeconds(10)),
-            new BaseTutorialStep("gazeexprtutorial", TimeSpan.FromSeconds(4)),
+            new BaseTutorialStep("gazeexprtutorial", TimeSpan.FromSeconds(10)),
             new GazeCaptureStep(eyePipelineEventBus, TimeSpan.FromSeconds(15), "gazeexpr", CaptureFlags.FLAG_FREE_EXPRESSION),
-            new BaseTutorialStep("blinktutorial", TimeSpan.FromSeconds(4)),
+            new BaseTutorialStep("blinktutorial", TimeSpan.FromSeconds(10)),
             eyeCaptureStepFactory.Create("blink",
                 CaptureFlags.FLAG_GOOD_DATA |
                 CaptureFlags.FLAG_IN_MOVEMENT |
@@ -474,20 +500,34 @@ public class EyeCalibration(
                 CaptureFlags.FLAG_ROUTINE_BIT1,
                 TimeSpan.FromSeconds(20)
             ),
+            new BaseTutorialStep("winklefttutorial", TimeSpan.FromSeconds(10)),
+            eyeCaptureStepFactory.CreateAsymmetricLids("winkleft",
+                CaptureFlags.FLAG_GOOD_DATA |
+                CaptureFlags.FLAG_IN_MOVEMENT |
+                CaptureFlags.FLAG_VERSION_BIT1,
+                TimeSpan.FromSeconds(10), leftLid: 1, rightLid: 0
+            ),
+            new BaseTutorialStep("winkrighttutorial", TimeSpan.FromSeconds(10)),
+            eyeCaptureStepFactory.CreateAsymmetricLids("winkright",
+                CaptureFlags.FLAG_GOOD_DATA |
+                CaptureFlags.FLAG_IN_MOVEMENT |
+                CaptureFlags.FLAG_VERSION_BIT1,
+                TimeSpan.FromSeconds(10), leftLid: 0, rightLid: 1
+            ),
 
-            new BaseTutorialStep("widentutorial", TimeSpan.FromSeconds(4)),
+            new BaseTutorialStep("widentutorial", TimeSpan.FromSeconds(10)),
                 eyeCaptureStepFactory.CreateGazeExpression("widen",
                 CaptureFlags.FLAG_GOOD_DATA | CaptureFlags.FLAG_IN_MOVEMENT | CaptureFlags.FLAG_VERSION_BIT1, TimeSpan.FromSeconds(20), widen: 1, lid: 1),
 
-            new BaseTutorialStep("squinttutorial", TimeSpan.FromSeconds(4)),
+            new BaseTutorialStep("squinttutorial", TimeSpan.FromSeconds(10)),
                 eyeCaptureStepFactory.CreateGazeExpression("squint",
                 CaptureFlags.FLAG_GOOD_DATA | CaptureFlags.FLAG_IN_MOVEMENT | CaptureFlags.FLAG_VERSION_BIT1, TimeSpan.FromSeconds(20), squint: 1, lid: 1),
 
-            new BaseTutorialStep("browtutorial", TimeSpan.FromSeconds(4)),
+            new BaseTutorialStep("browtutorial", TimeSpan.FromSeconds(10)),
                 eyeCaptureStepFactory.CreateGazeExpression("brow",
                 CaptureFlags.FLAG_GOOD_DATA | CaptureFlags.FLAG_IN_MOVEMENT | CaptureFlags.FLAG_VERSION_BIT1, TimeSpan.FromSeconds(20), browAngry: 1, lid: 1),
 
-            new MergeBinsStep("gaze.bin", "gazeexpr.bin", "blink.bin", "widen.bin", "squint.bin", "brow.bin"),
+            new MergeBinsStep("gaze.bin", "gazeexpr.bin", "blink.bin", "winkleft.bin", "winkright.bin", "widen.bin", "squint.bin", "brow.bin"),
             // new MergeBinsStep("gaze.bin", "blink.bin"),
             new TrainerCalibrationStep(trainer),
             new CommandDispatchStep("close")
@@ -501,7 +541,7 @@ public class EyeCalibration(
     {
         List<ICalibrationStep> steps =
         [
-            new BaseTutorialStep("gazetutorialshort", TimeSpan.FromSeconds(5)),
+            new BaseTutorialStep("gazetutorialshort", TimeSpan.FromSeconds(10)),
             new GazeCaptureStep(eyePipelineEventBus),
 
             new MergeBinsStep("gaze.bin", "blink.bin"),
@@ -517,7 +557,7 @@ public class EyeCalibration(
     {
         List<ICalibrationStep> steps =
         [
-            new BaseTutorialStep("blinktutorial", TimeSpan.FromSeconds(4)),
+            new BaseTutorialStep("blinktutorial", TimeSpan.FromSeconds(10)),
             eyeCaptureStepFactory.Create("blink",
                 CaptureFlags.FLAG_GOOD_DATA |
                 CaptureFlags.FLAG_IN_MOVEMENT |
@@ -526,7 +566,22 @@ public class EyeCalibration(
                 TimeSpan.FromSeconds(20)
             ),
 
-            new MergeBinsStep("gaze.bin", "blink.bin"),
+            new BaseTutorialStep("winklefttutorial", TimeSpan.FromSeconds(10)),
+            eyeCaptureStepFactory.CreateAsymmetricLids("winkleft",
+                CaptureFlags.FLAG_GOOD_DATA |
+                CaptureFlags.FLAG_IN_MOVEMENT |
+                CaptureFlags.FLAG_VERSION_BIT1,
+                TimeSpan.FromSeconds(10), leftLid: 1, rightLid: 0
+            ),
+            new BaseTutorialStep("winkrighttutorial", TimeSpan.FromSeconds(10)),
+            eyeCaptureStepFactory.CreateAsymmetricLids("winkright",
+                CaptureFlags.FLAG_GOOD_DATA |
+                CaptureFlags.FLAG_IN_MOVEMENT |
+                CaptureFlags.FLAG_VERSION_BIT1,
+                TimeSpan.FromSeconds(10), leftLid: 0, rightLid: 1
+            ),
+
+            new MergeBinsStep("gaze.bin", "blink.bin", "winkleft.bin", "winkright.bin"),
             new TrainerCalibrationStep(trainer),
             new CommandDispatchStep("close")
 

--- a/src/Baballonia.Desktop/Calibration/OverlayCalibrationService.cs
+++ b/src/Baballonia.Desktop/Calibration/OverlayCalibrationService.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using OverlaySDK.Packets;
 
 namespace Baballonia.Desktop.Calibration;
 
@@ -35,20 +36,28 @@ public class OverlayTrainerService(
             return (false, "Cannot start Overlay");
         }
 
-        overlayProgram.Start();
-
-        await Task.Delay(TimeSpan.FromSeconds(0.25));
-
         var overlayLogger = new OverlayLogger(logger);
 
         var sfactory = new SocketFactory();
-        var sock = sfactory.CreateServer("127.0.0.1", 2425);
+        // Start binding/listening before launching Godot. CreateServer waits for the client, so run
+        // it in the background; this removes the first-launch race caused by the old fixed delay.
+        var serverTask = Task.Run(() => sfactory.CreateServer("127.0.0.1", 2425), _tokenSource.Token);
+
+        overlayProgram.Start();
+
+        var sock = await serverTask.WaitAsync(TimeSpan.FromSeconds(30), _tokenSource.Token);
         overlayLogger.Info("Accepted connection");
 
         var tcp = new EventDrivenTcpClient(sock);
         var client = new EventDrivenJsonClient(tcp);
 
         var messageDispatcher = new OverlayMessageDispatcher(overlayLogger, client);
+
+        var readyHandler = new OverlayReadyHandler();
+        messageDispatcher.RegisterHandler(readyHandler);
+        await readyHandler.WaitAsync(_tokenSource.Token);
+        messageDispatcher.UnRegisterHandler(readyHandler);
+        overlayLogger.Info("Calibration overlay is ready");
 
         if (!Directory.Exists(Utils.ModelDataDirectory)) Directory.CreateDirectory(Utils.ModelDataDirectory);
         if (!Directory.Exists(Utils.ModelsDirectory)) Directory.CreateDirectory(Utils.ModelsDirectory);
@@ -63,7 +72,9 @@ public class OverlayTrainerService(
         };
         foreach (var calibrationStep in steps)
         {
+            logger.LogInformation("Starting calibration step {Step}", calibrationStep.Name);
             await calibrationStep.ExecuteAsync(messageDispatcher, _tokenSource.Token);
+            logger.LogInformation("Finished calibration step {Step}", calibrationStep.Name);
         }
 
         var srcPath = Path.Combine(Utils.ModelDataDirectory, "tuned_temporal_eye_tracking_latest.onnx");
@@ -84,5 +95,19 @@ public class OverlayTrainerService(
         await overlayProgram.WaitForExitAsync();
 
         return (true, string.Empty);
+    }
+
+    private sealed class OverlayReadyHandler : PacketHandlerAdapter
+    {
+        private readonly TaskCompletionSource _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitAsync(CancellationToken cancellationToken) =>
+            _ready.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        public override void OnRoutineFinishedPacket(RoutineFinishedPacket packet)
+        {
+            if (string.Equals(packet.RoutineName, "ready", StringComparison.OrdinalIgnoreCase))
+                _ready.TrySetResult();
+        }
     }
 }

--- a/src/Baballonia.Desktop/Calibration/OverlayProgram.cs
+++ b/src/Baballonia.Desktop/Calibration/OverlayProgram.cs
@@ -1,7 +1,10 @@
 ﻿using Baballonia.Assets;
+using Baballonia.Contracts;
+using Baballonia.Services;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -12,10 +15,11 @@ namespace Baballonia.Desktop.Calibration;
 public class OverlayProgram : IOverlayProgram
 {
     private readonly ILogger<OverlayProgram> _logger;
+    private readonly ILanguageSelectorService _languageSelectorService;
     private readonly string? _executablePath;
     private Process? _process;
 
-    public OverlayProgram(ILogger<OverlayProgram> logger)
+    public OverlayProgram(ILogger<OverlayProgram> logger, ILanguageSelectorService languageSelectorService)
     {
         var isWindows = OperatingSystem.IsWindows();
         var isArm = RuntimeInformation.OSArchitecture is Architecture.Arm or Architecture.Arm64 or Architecture.Armv6;
@@ -26,6 +30,7 @@ public class OverlayProgram : IOverlayProgram
             isWindows ? $"BabbleCalibration.{architectureIdentifier}.exe" : $"BabbleCalibration.{architectureIdentifier}");
         _executablePath = overlay;
         _logger = logger;
+        _languageSelectorService = languageSelectorService;
     }
 
     public bool CanStart()
@@ -55,13 +60,18 @@ public class OverlayProgram : IOverlayProgram
             OperatingSystem.IsWindows() && hasSteamVr ? XrMode.OpenVr :
             XrMode.OpenXr;
 
-        var launchArgs = $"-l {Resources.Godot_Locale}" + xrMode switch
+        var locale = GetGodotLocale();
+        // Pass both Godot's engine option and an application option. The latter is applied by
+        // MainScene as well, so exported builds cannot silently fall back to English.
+        var launchArgs = $"--language {locale} --baballonia-locale={locale}" + (xrMode switch
         {
             XrMode.Debug  => " --use-debug",
             XrMode.OpenVr => " --use-openvr",
             XrMode.OpenXr => " --xr-mode on",
             _ => throw new ArgumentOutOfRangeException()
-        };
+        });
+
+        _logger.LogInformation("Starting calibration overlay in {Mode} mode with locale {Locale}", xrMode, locale);
 
         var startInfo = new ProcessStartInfo
         {
@@ -85,6 +95,21 @@ public class OverlayProgram : IOverlayProgram
         };
 
         _process.Start();
+    }
+
+    private string GetGodotLocale()
+    {
+        var language = _languageSelectorService.Language;
+        var culture = language == LanguageSelectorService.DefaultLanguage
+            ? CultureInfo.CurrentUICulture
+            : CultureInfo.GetCultureInfo(language);
+
+        return culture.Name switch
+        {
+            "zh-CN" => "zh_CN",
+            "zh-TW" => "zh_TW",
+            _ => culture.TwoLetterISOLanguageName
+        };
     }
 
     private static bool IsProcessRunning(Process[] ps, string name) =>

--- a/src/Baballonia.Desktop/Calibration/TrainerService.cs
+++ b/src/Baballonia.Desktop/Calibration/TrainerService.cs
@@ -45,7 +45,7 @@ public partial class TrainerService(ILogger<TrainerService> logger) : ITrainerSe
 
         var currentEpoch = int.Parse(match.Groups[1].Value);
         var totalEpochs = int.Parse(match.Groups[2].Value);
-        var loss = double.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
+        var loss = double.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture);
 
         return new TrainerProgressReportPacket("Epoch", currentEpoch, totalEpochs, loss);
     }

--- a/src/Baballonia.Tests/Calibration/AsymmetricLidCaptureTests.cs
+++ b/src/Baballonia.Tests/Calibration/AsymmetricLidCaptureTests.cs
@@ -1,0 +1,34 @@
+using Baballonia.Desktop.Calibration;
+using Baballonia.Services.events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OpenCvSharp;
+using System;
+
+namespace Baballonia.Tests.Calibration;
+
+[TestClass]
+public class AsymmetricLidCaptureTests
+{
+    [DataTestMethod]
+    [DataRow(0f, 1f)]
+    [DataRow(1f, 0f)]
+    public void AddFrame_PreservesIndependentLidLabels(float leftLid, float rightLid)
+    {
+        var step = new BaseEyeCaptureStep(
+            Mock.Of<IEyePipelineEventBus>(),
+            "wink",
+            flags: 0,
+            time: TimeSpan.FromSeconds(1),
+            leftLid: leftLid,
+            rightLid: rightLid);
+
+        using var leftImage = new Mat(8, 8, MatType.CV_8UC1, Scalar.Black);
+        using var rightImage = new Mat(8, 8, MatType.CV_8UC1, Scalar.Black);
+
+        var frame = step.AddFrame([leftImage, rightImage]);
+
+        Assert.AreEqual(leftLid, frame.Header.RoutineLeftLid);
+        Assert.AreEqual(rightLid, frame.Header.RoutineRightLid);
+    }
+}


### PR DESCRIPTION
## Summary

Integrates independent left/right wink samples and localized instructions into the existing VR eye-calibration workflow.

### New calibration behavior

- add left-wink and right-wink tutorial/capture steps to full, quick, and blink-only calibration
- record asymmetric lid targets and merge both wink bins into the training dataset
- increase instruction pauses to 10 seconds
- pass Baballonia's selected locale to the Godot overlay
- add focused coverage for independent lid labels

### Integration changes required by the extended routine sequence

- wait until the overlay packet handler reports that it is ready before dispatching the first routine
- match completion packets to their originating routine so a delayed callback cannot complete the next added step
- show immediate trainer activity while the capture file is being indexed
- correct epoch-loss parsing used by the existing training progress display

The wink target pairs intentionally follow the existing trainer image/channel order:

| Routine | Left lid target | Right lid target |
| --- | ---: | ---: |
| `winkleft` | 1 (open) | 0 (closed) |
| `winkright` | 0 (closed) | 1 (open) |

The original camera-channel and XR-eye ordering remains unchanged.

## Companion overlay PR

https://github.com/Project-Babble/BabbleCalibration/pull/8

This PR targets `expr-opt` because the calibration code it extends currently lives on that branch.

## Testing

- `dotnet build src/Baballonia.Desktop/Baballonia.Desktop.csproj --no-restore`
- `dotnet publish -r win-x64 -c Release --self-contained -f net10.0`
- full OpenVR calibration and neural-network training completed manually
- independent left/right winks and pupil direction verified after training
- all transitions, localized instructions, reticle progress, and trainer progress verified in VR